### PR TITLE
Fix accuracy in kernels

### DIFF
--- a/src/SparseIR.jl
+++ b/src/SparseIR.jl
@@ -19,7 +19,7 @@ export LegendreBasis, MatsubaraConstBasis
 export FiniteTempBasisSet
 export LogisticKernel, RegularizedBoseKernel
 export CompositeBasis, CompositeBasisFunction, CompositeBasisFunctionFT
-export TauSampling, MatsubaraSampling, evaluate, fit
+export TauSampling, MatsubaraSampling, evaluate, fit, evaluate!, fit!
 
 @enum Statistics boson fermion
 

--- a/src/SparseIR.jl
+++ b/src/SparseIR.jl
@@ -2,7 +2,8 @@
 module SparseIR
 
 using MultiFloats: Float64x2
-using LinearAlgebra: dot, svd, SVD, QRIteration
+using LinearAlgebra: dot, svd, SVD, QRIteration, Factorization, factorize, cond, mul!, ldiv!
+import LinearAlgebra: cond
 using QuadGK: gauss, kronrod, quadgk
 using SpecialFunctions: SpecialFunctions
 

--- a/src/basis_set.jl
+++ b/src/basis_set.jl
@@ -20,13 +20,15 @@ and associated sparse-sampling objects.
 - smpl_wn_b::MatsubaraSampling: Sparse sampling for Matsubara frequency & boson
 - sve_result::Tuple{PiecewiseLegendrePoly,Vector{Float64},PiecewiseLegendrePoly}: Results of SVE
 """
-struct FiniteTempBasisSet
+struct FiniteTempBasisSet{
+    TSf<:TauSampling,MSf<:MatsubaraSampling,TSb<:TauSampling,MSb<:MatsubaraSampling
+}
     basis_f::_DEFAULT_FINITE_TEMP_BASIS
     basis_b::_DEFAULT_FINITE_TEMP_BASIS
-    smpl_tau_f::TauSampling{Float64,_DEFAULT_FINITE_TEMP_BASIS,Float64,Float64}
-    smpl_tau_b::TauSampling{Float64,_DEFAULT_FINITE_TEMP_BASIS,Float64,Float64}
-    smpl_wn_f::MatsubaraSampling{Int,_DEFAULT_FINITE_TEMP_BASIS,ComplexF64,Float64}
-    smpl_wn_b::MatsubaraSampling{Int,_DEFAULT_FINITE_TEMP_BASIS,ComplexF64,Float64}
+    smpl_tau_f::TSf # TauSampling{Float64,_DEFAULT_FINITE_TEMP_BASIS,Float64,Float64}
+    smpl_tau_b::TSb # TauSampling{Float64,_DEFAULT_FINITE_TEMP_BASIS,Float64,Float64}
+    smpl_wn_f::MSf # MatsubaraSampling{Int,_DEFAULT_FINITE_TEMP_BASIS,ComplexF64,Float64}
+    smpl_wn_b::MSb # MatsubaraSampling{Int,_DEFAULT_FINITE_TEMP_BASIS,ComplexF64,Float64}
 end
 
 """
@@ -37,7 +39,8 @@ associated sampling objects.
 Fermion and bosonic bases are constructed by SVE of the logistic kernel.
 """
 function FiniteTempBasisSet(
-    β::AbstractFloat, wmax::AbstractFloat, ε; sve_result=compute_sve(LogisticKernel(β * wmax); ε)
+    β::AbstractFloat, wmax::AbstractFloat, ε;
+    sve_result=compute_sve(LogisticKernel(β * wmax); ε),
 )
     # Create bases using the given sve results
     basis_f = FiniteTempBasis(fermion, β, wmax, ε; sve_result)

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -292,7 +292,7 @@ function matrix_from_gauss(kernel, gauss_x, gauss_y)
     # nodes are clustered most tightly.  Thus we have the need for the
     # matrix method.
     return @inbounds kernel.(
-        gauss_x.x, transpose(gauss_y.x), gauss_x.x .- gauss_x.a, gauss_x.b .- gauss_x.x
+        gauss_x.x, transpose(gauss_y.x), gauss_x.x_forward, gauss_x.x_backward
     )
 end
 

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -242,9 +242,9 @@ function segments_y end
 function segments_x(hints::SVEHintsLogistic)
     nzeros = max(round(Int, 15 * log10(hints.kernel.Λ)), 1)
     diffs = 1 ./ cosh.(0.143 * range(0; length=nzeros))
-    cumsum!(diffs, diffs; dims=1) # From here on, `diffs` contains the zeros
-    diffs ./= last(diffs)
-    return [-reverse(diffs); 0; diffs]
+    zeros = cumsum(diffs)
+    zeros ./= last(zeros)
+    return [-reverse(zeros); 0; zeros]
 end
 
 function segments_y(hints::SVEHintsLogistic)
@@ -253,33 +253,32 @@ function segments_y(hints::SVEHintsLogistic)
     # Zeros around -1 and 1 are distributed asymptotically identically
     leading_diffs = [0.01523, 0.03314, 0.04848, 0.05987, 0.06703, 0.07028, 0.07030, 0.06791,
         0.06391, 0.05896, 0.05358, 0.04814, 0.04288, 0.03795, 0.03342, 0.02932, 0.02565,
-        0.02239, 0.01951, 0.01699][begin:min(nzeros, 20)]
+        0.02239, 0.01951, 0.01699][1:min(nzeros, 20)]
 
     diffs = [leading_diffs; 0.25 ./ exp.(0.141 * (20:(nzeros - 1)))]
-
-    cumsum!(diffs, diffs; dims=1) # From here on, `diffs` contains the zeros
-    diffs ./= pop!(diffs)
-    diffs .-= 1
-    return [-1; diffs; 0; -reverse(diffs); 1]
+    zeros = cumsum(diffs)
+    zeros ./= pop!(zeros)
+    zeros .-= 1
+    return [-1; zeros; 0; -reverse(zeros); 1]
 end
 
 function segments_x(hints::SVEHintsRegularizedBose)
     # Somewhat less accurate...
     nzeros = max(round(Int, 15 * log10(hints.kernel.Λ)), 15)
     diffs = 1 ./ cosh.(0.18 * range(0; length=nzeros))
-    cumsum!(diffs, diffs; dims=1) # From here on, `diffs` contains the zeros
-    diffs ./= last(diffs)
-    return [-reverse(diffs); 0; diffs]
+    zeros = cumsum(diffs)
+    zeros ./= last(zeros)
+    return [-reverse(zeros); 0; zeros]
 end
 
 function segments_y(hints::SVEHintsRegularizedBose)
     nzeros = max(round(Int, 20 * log10(hints.kernel.Λ)), 20)
     i = range(0; length=nzeros)
     diffs = @. 0.12 / exp(0.0337 * i * log(i + 1))
-    cumsum!(diffs, diffs; dims=1) # From here on, `diffs` contains the zeros
-    diffs ./= pop!(diffs)
-    diffs .-= 1
-    return [-1; diffs; 0; -reverse(diffs); 1]
+    zeros = cumsum(diffs)
+    zeros ./= pop!(zeros)
+    zeros .-= 1
+    return [-1; zeros; 0; -reverse(zeros); 1]
 end
 
 """

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -15,7 +15,14 @@ basis coefficients `G_ir[l]` to time/frequency sampled on sparse points
 
 """
 abstract type AbstractSampling{T,Tmat,F<:Factorization} end
+
 cond(sampling::AbstractSampling) = cond(sampling.matrix)
+
+function Base.show(io::IO, smpl::S) where {S<:AbstractSampling}
+    println(io, S)
+    print(io, "Sampling points: ")
+    return println(io, smpl.sampling_points)
+end
 
 """
     TauSampling <: AbstractSampling

--- a/src/sve.jl
+++ b/src/sve.jl
@@ -161,7 +161,7 @@ SVD problems underlying the SVE.
 function matrices(sve::SamplingSVE)
     result = matrix_from_gauss(sve.kernel, sve.gauss_x, sve.gauss_y)
     result .*= sve.sqrtw_x
-    result .*= sve.sqrtw_y'
+    result .*= transpose(sve.sqrtw_y)
     return (result,)
 end
 matrices(sve::CentrosymmSVE) = (only(matrices(sve.even)), only(matrices(sve.odd)))

--- a/test/__conftest.jl
+++ b/test/__conftest.jl
@@ -3,6 +3,6 @@ if !@isdefined sve_logistic
         10 => SparseIR.compute_sve(LogisticKernel(10.0)),
         42 => SparseIR.compute_sve(LogisticKernel(42.0)),
         10_000 => SparseIR.compute_sve(LogisticKernel(10_000.0)),
-        (10_000,1e-12) => SparseIR.compute_sve(LogisticKernel(10_000.0), ε=1e-12),
+        (10_000, 1e-12) => SparseIR.compute_sve(LogisticKernel(10_000.0); ε=1e-12),
     )
 end

--- a/test/gauss.jl
+++ b/test/gauss.jl
@@ -10,6 +10,8 @@ function validategauss(rule)
     @test all(≥(rule.a), rule.x)
     @test issorted(rule.x)
     @test length(rule.x) == length(rule.w)
+    @test rule.x_forward ≈ rule.x .- rule.a
+    @test rule.x_backward ≈ rule.b .- rule.x
 end
 
 @testset "gauss.jl" begin

--- a/test/matsubara.jl
+++ b/test/matsubara.jl
@@ -3,8 +3,7 @@ using SparseIR
 
 @testset "matsubara.jl" begin
     @testset "single pole with stat = $stat, Λ = $Λ" for stat in (fermion, boson),
-        Λ in (1e1, 1e4)
-
+        Λ in (10, 42, 10_000)
         ε = (@isdefined Float64x2) ? nothing : 1e-15
         wmax = 1.0
         pole = 0.1 * wmax
@@ -12,8 +11,8 @@ using SparseIR
         basis = FiniteTempBasis(stat, β, wmax, ε; sve_result=sve_logistic[Λ])
 
         stat_shift = (stat == fermion) ? 1 : 0
-        weight = (stat == fermion) ? 1 : 1 / tanh(0.5 * Λ * pole / wmax)
-        gl = -basis.s .* basis.v(pole) * weight
+        spr = SparsePoleRepresentation(basis, [pole])
+        gl = to_IR(spr, [1.0])
 
         func_G(n) = 1 / (im * (2n + stat_shift) * π / β - pole)
 

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -61,8 +61,8 @@ using SparseIR
         @test result == result_iter
     end
 
-    @testset "overlap with Λ = $Λ, atol = $atol" for (Λ, atol) in
-                                                     ((42, 1e-13), (10^4, 1e-13))
+    @testset "overlap with Λ = $Λ, atol = $atol" for Λ in (10, 42, 10_000)
+        atol = 1e-13
         u, s, v = sve_logistic[Λ]
 
         # Keep only even number of polynomials

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -61,7 +61,7 @@ using SparseIR
         @test result == result_iter
     end
 
-    @testset "overlap with Λ = $Λ, atol = $atol" for Λ in (10, 42, 10_000)
+    @testset "overlap with Λ = $Λ" for Λ in (10, 42, 10_000)
         atol = 1e-13
         u, s, v = sve_logistic[Λ]
 
@@ -74,7 +74,7 @@ using SparseIR
         @test overlap(u[1], u[2]) ≈ 0 rtol = 0 atol = atol
 
         ref = float.(eachindex(s) .== 1)
-        @test all(isapprox.(overlap(u[1], u), ref, rtol=0, atol=atol))
+        @test all(isapprox.(overlap(u[1], u), ref; rtol=0, atol))
     end
 
     @testset "eval unique" begin

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -3,7 +3,7 @@ using SparseIR
 
 using Random, LinearAlgebra
 
-#include("conftest.jl")
+include("__conftest.jl")
 
 @testset "sampling.jl" begin
     @testset "decomp" begin

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -47,8 +47,7 @@ include("__conftest.jl")
         end
     end
 
-    #@testset "τ noise with stat = $stat, Λ = $Λ" for stat in (boson, fermion), Λ in (10, 42)
-    @testset "τ noise with stat = $stat, Λ = $Λ" for stat in (fermion,), Λ in (10, )
+    @testset "τ noise with stat = $stat, Λ = $Λ" for stat in (boson, fermion), Λ in (10, 42)
         basis = DimensionlessBasis(stat, Λ; sve_result=sve_logistic[Λ])
         smpl = TauSampling(basis)
         @test issorted(smpl.sampling_points)

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -57,7 +57,7 @@ include("__conftest.jl")
         @test isapprox(Gℓ, Gℓ_n, atol=12 * noise * Gℓ_magn, rtol=0)
     end
 
-    @testset "τ noise with stat = $stat, Λ = $Λ" for stat in (boson, fermion), Λ in (10, 42)
+    @testset "iω noise with stat = $stat, Λ = $Λ" for stat in (boson, fermion), Λ in (10, 42)
         basis = DimensionlessBasis(stat, Λ; sve_result=sve_logistic[Λ])
         smpl = MatsubaraSampling(basis)
         @test issorted(smpl.sampling_points)
@@ -84,6 +84,6 @@ include("__conftest.jl")
         fit!(Gℓ_n_inplace, smpl, Giwn_n)
         @test Gℓ_n == Gℓ_n_inplace
 
-        @test isapprox(Gℓ, Gℓ_n, atol=13 * noise * Gℓ_magn, rtol=0)
+        @test isapprox(Gℓ, Gℓ_n, atol=40 * noise * Gℓ_magn, rtol=0)
     end
 end

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -27,23 +27,26 @@ include("__conftest.jl")
         @test A \ y ≈ Ad \ y atol = 1e-14 * norm_A rtol = 0
     end
 
-    @testset "evaluate" begin
-        Λ = 10
-        basis = DimensionlessBasis(fermion, Λ; sve_result=sve_logistic[Λ])
+    @testset "evaluate with stat = $stat, Λ = $Λ" for stat in (boson, fermion), Λ in (10, 42)
+        basis = DimensionlessBasis(stat, Λ; sve_result=sve_logistic[Λ])
         smpl = TauSampling(basis)
         @test issorted(smpl.sampling_points)
         Random.seed!(5318008)
-        newaxis = [CartesianIndex()]
 
         shape = (2, 3, 4)
-        rhol = Random.randn(length(basis), prod(shape)) + im * Random.randn(length(basis), prod(shape))
-        flatgl = - basis.s[:, newaxis] .* rhol
+        rhol = randn(ComplexF64, (length(basis), shape...))
+        originalgl = -basis.s .* rhol
         for dim in 1:length(shape)
-            gl = SparseIR.movedim(reshape(flatgl, :, shape...), 1 => dim)
-            gtau = evaluate(smpl, gl, dim=dim)
-            @test size(gtau) == (size(gl)[1:(dim-1)]..., length(smpl.sampling_points), size(gl)[(dim+1):end]...)
+            gl = SparseIR.movedim(originalgl, 1 => dim)
+            gtau = evaluate(smpl, gl; dim)
+            @test size(gtau) == (
+                size(gl)[1:(dim - 1)]...,
+                length(smpl.sampling_points),
+                size(gl)[(dim + 1):end]...,
+            )
 
-            # TODO: implement check of gtau
+            gl_from_tau = fit(smpl, gtau; dim)
+            @test gl_from_tau ≈ gl
         end
     end
 
@@ -77,7 +80,9 @@ include("__conftest.jl")
         @test isapprox(Gℓ, Gℓ_n, atol=12 * noise * Gℓ_magn, rtol=0)
     end
 
-    @testset "iω noise with stat = $stat, Λ = $Λ" for stat in (boson, fermion), Λ in (10, 42)
+    @testset "iω noise with stat = $stat, Λ = $Λ" for stat in (boson, fermion),
+        Λ in (10, 42)
+
         basis = DimensionlessBasis(stat, Λ; sve_result=sve_logistic[Λ])
         smpl = MatsubaraSampling(basis)
         @test issorted(smpl.sampling_points)

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -47,7 +47,8 @@ include("__conftest.jl")
         end
     end
 
-    @testset "τ noise with stat = $stat, Λ = $Λ" for stat in (boson, fermion), Λ in (10, 42)
+    #@testset "τ noise with stat = $stat, Λ = $Λ" for stat in (boson, fermion), Λ in (10, 42)
+    @testset "τ noise with stat = $stat, Λ = $Λ" for stat in (fermion,), Λ in (10, )
         basis = DimensionlessBasis(stat, Λ; sve_result=sve_logistic[Λ])
         smpl = TauSampling(basis)
         @test issorted(smpl.sampling_points)

--- a/test/spr.jl
+++ b/test/spr.jl
@@ -3,7 +3,9 @@
         beta = 10_000
         wmax = 1.0
         eps = 1e-12
-        basis = FiniteTempBasis(stat, float(beta), wmax, eps, sve_result=sve_logistic[(beta,eps)])
+        basis = FiniteTempBasis(
+            stat, float(beta), wmax, eps; sve_result=sve_logistic[(beta, eps)]
+        )
         spr = SparsePoleRepresentation(basis)
 
         Random.seed!(4711)


### PR DESCRIPTION
Doesn't quite fix #20 yet, though it's made an improvement; Compare the singular values' errors now to those in the issue:

<img width="726" alt="Screenshot 2022-05-25 at 17 56 30" src="https://user-images.githubusercontent.com/4489583/170305632-a1d8ccce-9e9f-45ea-8bae-eb8481311316.png">

