### PR TITLE
Introduce type for Matsubara frequencies

### DIFF
--- a/src/SparseIR.jl
+++ b/src/SparseIR.jl
@@ -23,12 +23,14 @@ export CompositeBasis, CompositeBasisFunction, CompositeBasisFunctionFT
 export TauSampling, MatsubaraSampling, TauSampling64, MatsubaraSampling64, evaluate, fit,
     evaluate!, fit!, workarrlengthfit
 
-@enum Statistics boson fermion
-
 include("_linalg.jl")
 include("_roots.jl")
 include("_specfuncs.jl")
 using ._LinAlg: tsvd
+
+include("freq.jl")
+const boson = Bosonic()
+const fermion = Fermionic()
 
 include("svd.jl")
 include("gauss.jl")

--- a/src/SparseIR.jl
+++ b/src/SparseIR.jl
@@ -13,6 +13,7 @@ Base.cosh(x::Float64x2) = setprecision(() -> Float64x2(cosh(big(x))), precision(
 Base.Math.hypot(x::Float64x2, y::Float64x2) = Base.Math._hypot(x, y) # FIXME: remove if MultiFloats is fixed
 
 export fermion, boson
+export MatsubaraFreq, BosonicFreq, FermionicFreq, pioverbeta
 export DimensionlessBasis, FiniteTempBasis
 export SparsePoleRepresentation, to_IR, from_IR
 export overlap

--- a/src/augment.jl
+++ b/src/augment.jl
@@ -19,7 +19,7 @@ struct LegendreBasis{T<:AbstractFloat, S<:Statistics} <: AbstractBasis
     β::Float64
     cl::Vector{T}
     u::PiecewiseLegendrePolyVector{T}
-    uhat::PiecewiseLegendreFTVector{T}
+    uhat::PiecewiseLegendreFTVector{T,S}
 end
 
 function LegendreBasis(
@@ -42,8 +42,7 @@ function LegendreBasis(
 
     # uhat
     uhat_base = PiecewiseLegendrePolyVector(sqrt(beta) .* data, Float64[-1, 1]; symm)
-    even_odd = Dict(fermion => :odd, boson => :even)[statistics]
-    uhat = hat.(uhat_base, even_odd)
+    uhat = map(ui -> PiecewiseLegendreFT(ui, statistics), uhat_base)
 
     return LegendreBasis(statistics, beta, cl, u, uhat)
 end

--- a/src/augment.jl
+++ b/src/augment.jl
@@ -14,8 +14,8 @@ In this type, the basis functions are defined by
 where c_l are additional l-dependent constant factors.
 By default, we take c_l = 1, which reduces to the original definition.
 """
-struct LegendreBasis{T<:AbstractFloat} <: AbstractBasis
-    statistics::Statistics
+struct LegendreBasis{T<:AbstractFloat, S<:Statistics} <: AbstractBasis
+    statistics::S
     β::Float64
     cl::Vector{T}
     u::PiecewiseLegendrePolyVector{T}
@@ -73,8 +73,8 @@ end
 """
 Constant term in matsubara-frequency domain
 """
-struct MatsubaraConstBasis{T<:AbstractFloat} <: AbstractBasis
-    statistics::Statistics
+struct MatsubaraConstBasis{T<:AbstractFloat,S<:Statistics} <: AbstractBasis
+    statistics::S
     β::Float64
     uhat::_ConstTerm{T}
 end

--- a/src/augment.jl
+++ b/src/augment.jl
@@ -62,12 +62,14 @@ function default_tau_sampling_points(basis::LegendreBasis)
     return (getbeta(basis) / 2) .* (x .+ 1)
 end
 
-struct _ConstTerm{T<:Number}
+struct _ConstTerm{T<:Number, S<:Statistics}
+    statistics::S
     value::T
 end
 
-(ct::_ConstTerm)(n::AbstractVector{<:Integer}) = fill(ct.value, (1, length(n)))
-(ct::_ConstTerm)(n::Integer) = ct([n])
+(ct::_ConstTerm{T,S})(::MatsubaraFreq{S}) where {T,S} = ct.value
+(ct::_ConstTerm)(n::Integer) = ct(MatsubaraFreq(n))
+(ct::_ConstTerm)(n::AbstractArray) = ct.(n)
 
 """
 Constant term in matsubara-frequency domain
@@ -75,12 +77,12 @@ Constant term in matsubara-frequency domain
 struct MatsubaraConstBasis{T<:AbstractFloat,S<:Statistics} <: AbstractBasis
     statistics::S
     β::Float64
-    uhat::_ConstTerm{T}
+    uhat::_ConstTerm{T,S}
 end
 
 function MatsubaraConstBasis(statistics::Statistics, beta::Float64; value=1)
     beta > 0 || throw(DomainError(beta, "inverse temperature beta must be positive"))
-    return MatsubaraConstBasis(statistics, beta, _ConstTerm(value))
+    return MatsubaraConstBasis(statistics, beta, _ConstTerm(statistics, value))
 end
 
 Base.size(::MatsubaraConstBasis) = (1,)

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -88,8 +88,8 @@ function DimensionlessBasis(
     # The radius of convergence of the asymptotic expansion is Λ/2,
     # so for significantly larger frequencies we use the asymptotics,
     # since it has lower relative error.
-    conv_radius = 40 * kernel.Λ
-    û = map(ui -> PiecewiseLegendreFT(ui, statistics, conv_radius), u)
+    û = map(ui -> PiecewiseLegendreFT(ui, statistics,
+                                      conv_radius(kernel)), u)
     return DimensionlessBasis(kernel, u, û, s, v, statistics)
 end
 
@@ -215,8 +215,8 @@ function FiniteTempBasis(
     # HACK: as we don't yet support Fourier transforms on anything but the
     # unit interval, we need to scale the underlying data.  This breaks
     # the correspondence between U.hat and Uhat though.
-    conv_radius = 40 * kernel.Λ
-    û = map(ui -> PiecewiseLegendreFT(scale(ui, √β), statistics, conv_radius), u)
+    û = map(ui -> PiecewiseLegendreFT(scale(ui, √β), statistics,
+                                      conv_radius(kernel)), u)
 
     return FiniteTempBasis(kernel, sve_result, statistics, float(β), u_, v_, s_, û)
 end

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -308,18 +308,19 @@ function _default_matsubara_sampling_points(uhat, mitigate=true)
     # the two sampling problems within a factor of 2.
     if mitigate
         wn_outer = [first(wn), last(wn)]
-        wn_diff = 2 * round.(Int, 0.025 * wn_outer)
+        wn_diff = BosonicFreq.(2 * round.(Int, 0.025 * Integer.(wn_outer)))
         length(wn) ≥ 20 && append!(wn, wn_outer - wn_diff)
         length(wn) ≥ 42 && append!(wn, wn_outer + wn_diff)
+        sort!(wn)
         unique!(wn)
     end
 
-    if iseven(first(wn))
+    # FIXME: I DONT UNDERSTAND THIS!?!  Why is this necessary?
+    if zeta(first(wn)) == false
         pushfirst!(wn, 0)
+        sort!(wn)
         unique!(wn)
     end
-
-    sort!(wn)
 
     return wn
 end

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -60,13 +60,13 @@ These functions are stored as piecewise Legendre polynomials.
 
 See also [`FiniteTempBasis`](@ref) for a basis directly in time/frequency.
 """
-struct DimensionlessBasis{K<:AbstractKernel,T<:AbstractFloat} <: AbstractBasis
+struct DimensionlessBasis{K<:AbstractKernel,T<:AbstractFloat,S<:Statistics} <: AbstractBasis
     kernel::K
     u::PiecewiseLegendrePolyVector{T}
     uhat::PiecewiseLegendreFTVector{T}
     s::Vector{T}
     v::PiecewiseLegendrePolyVector{T}
-    statistics::Statistics
+    statistics::S
 end
 
 function Base.show(io::IO, a::DimensionlessBasis)
@@ -137,7 +137,7 @@ julia> giw = transpose(basis.uhat([1, 3, 5, 7])) * gl
 - `u::PiecewiseLegendrePolyVector`:
   Set of IR basis functions on the imaginary time (`tau`) axis.
   These functions are stored as piecewise Legendre polynomials.
-  
+
   To obtain the value of all basis functions at a point or a array of
   points `x`, you can call the function `u(x)`.  To obtain a single
   basis function, a slice or a subset `l`, you can use `u[l]`.
@@ -162,12 +162,12 @@ julia> giw = transpose(basis.uhat([1, 3, 5, 7])) * gl
   points `w`, you can call the function `v(w)`.  To obtain a single
   basis function, a slice or a subset `l`, you can use `v[l]`.
 """
-struct FiniteTempBasis{K,T} <: AbstractBasis
+struct FiniteTempBasis{K,T,S} <: AbstractBasis
     kernel::K
     sve_result::Tuple{
         PiecewiseLegendrePolyVector{T},Vector{T},PiecewiseLegendrePolyVector{T}
     }
-    statistics::Statistics
+    statistics::S
     β::T
     u::PiecewiseLegendrePolyVector{T}
     v::PiecewiseLegendrePolyVector{T}
@@ -218,7 +218,7 @@ function FiniteTempBasis(
     û_base = scale.(u, √β)
 
     conv_radius = 40 * kernel.Λ
-    even_odd = Dict(fermion => :odd, boson => :even)[statistics]
+    even_odd = Dict(Fermionic => :odd, Bosonic => :even)[typeof(statistics)]
     û = hat.(û_base, even_odd; n_asymp=conv_radius)
 
     return FiniteTempBasis(kernel, sve_result, statistics, float(β), u_, v_, s_, û)

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -269,7 +269,7 @@ Default sampling points on the imaginary time/`x` axis.
 default_tau_sampling_points(basis::AbstractBasis) = _default_sampling_points(basis.u)
 
 """
-    _default_matsubara_sampling_points(basis; mitigate=true)
+    default_matsubara_sampling_points(basis; mitigate=true)
 
 Default sampling points on the imaginary frequency axis.
 """
@@ -307,16 +307,17 @@ function _default_matsubara_sampling_points(uhat, mitigate=true)
     # frequency with two carefully chosen oversampling points, which brings
     # the two sampling problems within a factor of 2.
     if mitigate
-        wn_outer = [first(wn), last(wn)]
-        wn_diff = BosonicFreq.(2 * round.(Int, 0.025 * Integer.(wn_outer)))
-        length(wn) ≥ 20 && append!(wn, wn_outer - wn_diff)
-        length(wn) ≥ 42 && append!(wn, wn_outer + wn_diff)
+        for wn_max in (first(wn), last(wn))
+            wn_diff = BosonicFreq(2 * round(Int, 0.025 * Integer(wn_max)))
+            length(wn) ≥ 20 && push!(wn, wn_max - sign(wn_max) * wn_diff)
+            length(wn) ≥ 42 && push!(wn, wn_max + sign(wn_max) * wn_diff)
+        end
         sort!(wn)
         unique!(wn)
     end
 
-    # FIXME: I DONT UNDERSTAND THIS!?!  Why is this necessary?
-    if zeta(first(wn)) == false
+    # For bosonic function
+    if uhat.stat == Bosonic()
         pushfirst!(wn, 0)
         sort!(wn)
         unique!(wn)

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -88,8 +88,8 @@ function DimensionlessBasis(
     # The radius of convergence of the asymptotic expansion is Λ/2,
     # so for significantly larger frequencies we use the asymptotics,
     # since it has lower relative error.
-    even_odd = Dict(fermion => :odd, boson => :even)[statistics]
-    û = hat.(u, even_odd; n_asymp=conv_radius(kernel))
+    conv_radius = 40 * kernel.Λ
+    û = map(ui -> PiecewiseLegendreFT(ui, statistics, conv_radius), u)
     return DimensionlessBasis(kernel, u, û, s, v, statistics)
 end
 
@@ -172,7 +172,7 @@ struct FiniteTempBasis{K,T,S} <: AbstractBasis
     u::PiecewiseLegendrePolyVector{T}
     v::PiecewiseLegendrePolyVector{T}
     s::Vector{T}
-    uhat::PiecewiseLegendreFTVector{T}
+    uhat::PiecewiseLegendreFTVector{T,S}
 end
 
 const _DEFAULT_FINITE_TEMP_BASIS = FiniteTempBasis{LogisticKernel,Float64}
@@ -215,11 +215,8 @@ function FiniteTempBasis(
     # HACK: as we don't yet support Fourier transforms on anything but the
     # unit interval, we need to scale the underlying data.  This breaks
     # the correspondence between U.hat and Uhat though.
-    û_base = scale.(u, √β)
-
     conv_radius = 40 * kernel.Λ
-    even_odd = Dict(Fermionic => :odd, Bosonic => :even)[typeof(statistics)]
-    û = hat.(û_base, even_odd; n_asymp=conv_radius)
+    û = map(ui -> PiecewiseLegendreFT(scale(ui, √β), statistics, conv_radius), u)
 
     return FiniteTempBasis(kernel, sve_result, statistics, float(β), u_, v_, s_, û)
 end

--- a/src/composite.jl
+++ b/src/composite.jl
@@ -33,9 +33,13 @@ end
 """
 Evaluate basis function at frequency n
 """
-function (obj::CompositeBasisFunctionFT)(n::Union{Int,Vector{Int}})
-    return hcat(p(n) for p in obj.polys)
-end
+(obj::CompositeBasisFunctionFT)(n::MatsubaraFreq) = hcat(p(n) for p in obj.polys)
+(obj::CompositeBasisFunctionFT)(n::AbstractVector{MatsubaraFreq}) = hcat(p(n) for p in obj.polys)
+
+(obj::CompositeBasisFunctionFT)(n::Integer) = obj(MatsubaraFreq(n))
+(obj::CompositeBasisFunctionFT)(n::AbstractVector{Integer}) = obj(MatsubaraFreq.(n))
+
+
 
 struct CompositeBasis <: AbstractBasis
     beta::Float64

--- a/src/freq.jl
+++ b/src/freq.jl
@@ -85,6 +85,15 @@ Integer(a::MatsubaraFreq) = a.n
 """Get prefactor `n` for the Matsubara frequency `ω = n*π/β`"""
 Int(a::MatsubaraFreq) = a.n
 
+"""Get value of the Matsubara frequency `ω = n*π/β`"""
+function value(a::MatsubaraFreq, beta::Real)
+    beta > 0 || throw(DomainError(beta, "beta must be positive"))
+    return a.n * (π/beta)
+end
+
+"""Get complex value of the Matsubara frequency `iω = iπ/β * n`"""
+valueim(a::MatsubaraFreq, beta::Real) = 1im * value(a, beta)
+
 """Get statistics `ζ` for Matsubara frequency `ω = (2*m+ζ)*π/β`"""
 zeta(a::MatsubaraFreq) = zeta(a.stat)
 

--- a/src/freq.jl
+++ b/src/freq.jl
@@ -21,3 +21,127 @@ struct Bosonic <: Statistics end
 
 zeta(::Fermionic) = true
 zeta(::Bosonic) = false
+
+Base.:+(::Fermionic, ::Bosonic)   = Fermionic()
+Base.:+(::Bosonic,   ::Fermionic) = Fermionic()
+Base.:+(::Fermionic, ::Fermionic) = Bosonic()
+Base.:+(::Bosonic,   ::Bosonic)   = Bosonic()
+
+
+"""
+    MatsubaraFreq(n)
+
+Prefactor `n` of the Matsubara frequency `ω = n*π/β`
+
+Struct representing the Matsubara frequency ω entering the Fourier transform of
+a propagator G(τ) on imaginary time τ to its Matsubara equivalent Ĝ(iω) on the
+imaginary-frequency axis:
+
+            β
+    Ĝ(iω) = ∫  dτ exp(iωτ) G(τ)      with    ω = n π/β,
+            0
+
+where β is inverse temperature and  by convention we include the imaginary unit
+in the frequency argument, i.e, Ĝ(iω).  The frequencies depend on the
+statistics of the propagator, i.e., we have that:
+
+    G(τ - β) = ± G(τ)
+
+where + is for bosons and - is for fermions.  The frequencies are restricted
+accordingly.
+
+  - Bosonic frequency (`S == Fermionic`): `n` even (periodic in β)
+  - Fermionic frequency (`S == Bosonic`): `n` odd (anti-periodic in β)
+"""
+struct MatsubaraFreq{S <: Statistics} <: Number
+    stat::S
+    n::Int
+
+    MatsubaraFreq(stat::Statistics, n::Integer) = new{typeof(stat)}(stat, n)
+
+    function MatsubaraFreq{S}(n::Integer) where {S <: Statistics}
+        stat = S()
+        if isodd(n) != zeta(stat)
+            throw(ArgumentError("Frequency $(n)π/β is not $stat"))
+        end
+        new{S}(stat, n)
+    end
+end
+
+const BosonicFreq = MatsubaraFreq{Bosonic}
+
+const FermionicFreq = MatsubaraFreq{Fermionic}
+
+MatsubaraFreq(n::Integer) = MatsubaraFreq(Statistics(isodd(n)), n)
+
+"""Get prefactor `n` for the Matsubara frequency `ω = n*π/β`"""
+Integer(a::MatsubaraFreq) = a.n
+
+"""Get prefactor `n` for the Matsubara frequency `ω = n*π/β`"""
+Int(a::MatsubaraFreq) = a.n
+
+"""Get statistics `ζ` for Matsubara frequency `ω = (2*m+ζ)*π/β`"""
+zeta(a::MatsubaraFreq) = zeta(a.stat)
+
+Base.:+(a::MatsubaraFreq, b::MatsubaraFreq) =
+    MatsubaraFreq(a.stat + b.stat, a.n + b.n)
+
+Base.:-(a::MatsubaraFreq, b::MatsubaraFreq) =
+    MatsubaraFreq(a.stat + b.stat, a.n - b.n)
+
+Base.:+(a::MatsubaraFreq) = a
+
+Base.:-(a::MatsubaraFreq) = MatsubaraFreq(a.stat, -a.n)
+
+Base.:*(a::BosonicFreq, c::Integer) = MatsubaraFreq(a.stat, a.n * c)
+
+Base.:*(a::FermionicFreq, c::Integer) = MatsubaraFreq(a.n * c)
+
+Base.:*(c::Integer, a::MatsubaraFreq) = a * c
+
+Base.zero(::MatsubaraFreq) = MatsubaraFreq(0)
+
+Base.iszero(self::MatsubaraFreq) = self.n == 0
+
+Base.isless(a::MatsubaraFreq, b::MatsubaraFreq) = isless(a.n, b.n)
+
+Base.isequal(a::MatsubaraFreq, b::MatsubaraFreq) = isequal(a.n, b.n)
+
+function Base.show(io::IO, self::MatsubaraFreq)
+    if self.n == 0
+        print(io, "0")
+    elseif self.n == 1
+        print(io, "π/β")
+    else
+        print(io, self.n, "π/β")
+    end
+end
+
+const pioverbeta = MatsubaraFreq(1)
+
+Base.oneunit(::MatsubaraFreq) = pioverbeta
+
+"""
+Dense grid of frequencies in an implicit representation
+"""
+struct FreqRange{A<:Statistics} <: OrdinalRange{MatsubaraFreq{A}, BosonicFreq}
+    start::MatsubaraFreq{A}
+    stop::MatsubaraFreq{A}
+
+    function FreqRange(start::MatsubaraFreq{A}, stop::MatsubaraFreq{A}) where {A}
+        if stop < start
+            stop = start - 2 * pioverbeta
+        end
+        new{A}(start, stop)
+    end
+end
+
+Base.first(self::FreqRange) = self.start
+
+Base.last(self::FreqRange) = self.stop
+
+Base.step(::FreqRange) = BosonicFreq(2)
+
+Base.length(self::FreqRange) = Integer(self.stop - self.start) ÷ 2 + 1
+
+Base.:(:)(start::MatsubaraFreq, stop::MatsubaraFreq) = FreqRange(start, stop)

--- a/src/freq.jl
+++ b/src/freq.jl
@@ -1,0 +1,23 @@
+export
+    MatsubaraFreq,
+    BosonicFreq,
+    FermionicFreq,
+    pioverbeta
+
+"""
+    Statistics(zeta)
+
+Abstract type for quantum statistics (fermionic/bosonic/etc.)
+"""
+abstract type Statistics end
+
+Statistics(zeta::Bool) = zeta ? Fermionic() : Bosonic()
+
+"""Fermionic statistics."""
+struct Fermionic <: Statistics end
+
+"""Bosonic statistics."""
+struct Bosonic <: Statistics end
+
+zeta(::Fermionic) = true
+zeta(::Bosonic) = false

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -345,8 +345,8 @@ function findextrema(polyFT::PiecewiseLegendreFT, part=nothing, grid=DEFAULT_GRI
     f = _func_for_part(polyFT, part)
     x₀ = _discrete_extrema(f, grid)
     x₀ .= 2x₀ .+ zeta(polyFT.stat)
-
-    return _symmetrize_matsubara(x₀)
+    x₀ = _symmetrize_matsubara(x₀)
+    return map(xi -> MatsubaraFreq(polyFT.stat, xi), x₀)
 end
 
 function _func_for_part(polyFT::PiecewiseLegendreFT, part=nothing)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -43,8 +43,8 @@ end
 """
     TauSampling(basis[, sampling_points])
 
-Construct a `TauSampling` object. If not given, the `sampling_points` are chosen as 
-the extrema of the highest-order basis function in imaginary time. This turns out 
+Construct a `TauSampling` object. If not given, the `sampling_points` are chosen as
+the extrema of the highest-order basis function in imaginary time. This turns out
 to be close to optimal with respect to conditioning for this size (within a few percent).
 """
 function TauSampling(
@@ -80,19 +80,11 @@ struct MatsubaraSampling{T,Tmat,F<:SVD} <: AbstractSampling{T,Tmat,F}
     matrix_svd::F
 end
 
-const MatsubaraSampling64 = @static if VERSION < v"1.9-"
-    MatsubaraSampling{Int64,ComplexF64,SVD{ComplexF64,Float64,Matrix{ComplexF64}}}
-else
-    MatsubaraSampling{
-        Int64,ComplexF64,SVD{ComplexF64,Float64,Matrix{ComplexF64},Vector{Float64}}
-    }
-end
-
 """
     MatsubaraSampling(basis[, sampling_points])
 
-Construct a `MatsubaraSampling` object. If not given, the `sampling_points` are chosen as 
-the (discrete) extrema of the highest-order basis function in Matsubara. This turns out 
+Construct a `MatsubaraSampling` object. If not given, the `sampling_points` are chosen as
+the (discrete) extrema of the highest-order basis function in Matsubara. This turns out
 to be close to optimal with respect to conditioning for this size (within a few percent).
 """
 function MatsubaraSampling(

--- a/src/spr.jl
+++ b/src/spr.jl
@@ -7,7 +7,7 @@ end
 # FIXME: only works for vectors
 function (basis::MatsubaraPoleBasis{S})(n::AbstractVector{MatsubaraFreq{S}}) where {S}
     beta = getbeta(basis)
-    iv = (im * π / beta) .* Integer.(n)
+    iv = valueim.(n, beta)
     if basis.statistics == fermion
         return 1 ./ (transpose(iv) .- basis.poles)
     else

--- a/src/spr.jl
+++ b/src/spr.jl
@@ -1,6 +1,6 @@
-struct MatsubaraPoleBasis <: AbstractBasis
+struct MatsubaraPoleBasis{S <: Statistics} <: AbstractBasis
     β::Float64
-    statistics::Statistics
+    statistics::S
     poles::Vector{Float64}
 end
 
@@ -14,10 +14,10 @@ function (basis::MatsubaraPoleBasis)(n::Vector{<:Integer})
     end
 end
 
-struct TauPoleBasis <: AbstractBasis
+struct TauPoleBasis{S <: Statistics} <: AbstractBasis
     β::Float64
     poles::Vector{Float64}
-    statistics::Statistics
+    statistics::S
     wmax::Float64
 end
 
@@ -40,12 +40,12 @@ end
 """
 Sparse pole representation
 """
-struct SparsePoleRepresentation{T<:AbstractFloat} <: AbstractBasis
+struct SparsePoleRepresentation{T<:AbstractFloat, S<:Statistics} <: AbstractBasis
     basis::AbstractBasis
     poles::Vector{T}
     u::TauPoleBasis
     uhat::MatsubaraPoleBasis
-    statistics::Statistics
+    statistics::S
     fitmat::Matrix{Float64}
     matrix::SVD
 end

--- a/src/spr.jl
+++ b/src/spr.jl
@@ -4,15 +4,18 @@ struct MatsubaraPoleBasis{S <: Statistics} <: AbstractBasis
     poles::Vector{Float64}
 end
 
-function (basis::MatsubaraPoleBasis)(n::Vector{<:Integer})
+# FIXME: only works for vectors
+function (basis::MatsubaraPoleBasis{S})(n::AbstractVector{MatsubaraFreq{S}}) where {S}
     beta = getbeta(basis)
-    iv = (im * π / beta) .* n
+    iv = (im * π / beta) .* Integer.(n)
     if basis.statistics == fermion
         return 1 ./ (transpose(iv) .- basis.poles)
     else
         return tanh.((0.5 * beta) .* basis.poles) ./ (transpose(iv) .- basis.poles)
     end
 end
+
+(basis::MatsubaraPoleBasis)(n::AbstractVector{<:Integer}) = basis(MatsubaraFreq.(n))
 
 struct TauPoleBasis{S <: Statistics} <: AbstractBasis
     β::Float64

--- a/test/augment.jl
+++ b/test/augment.jl
@@ -39,7 +39,7 @@ using AssociatedLegendrePolynomials: Plm
         gl_from_τ = fit(τ_smpl, gτ)
 
         matsu_smpl = MatsubaraSampling(basis)
-        giv = 1 ./ ((im * π / β) * matsu_smpl.sampling_points .- pole)
+        giv = 1 ./ ((im * π / β) * Integer.(matsu_smpl.sampling_points) .- pole)
         gl_from_matsu = fit(matsu_smpl, giv)
 
         #println(maximum(abs, gl_from_τ-gl_from_matsu))

--- a/test/augment.jl
+++ b/test/augment.jl
@@ -7,9 +7,8 @@ using AssociatedLegendrePolynomials: Plm
         beta = 2.0
         value = 1.1
         b = MatsubaraConstBasis(stat, beta; value)
-        shift::Int = Dict(fermion => 1, boson => 0)[stat]
-        n = 2 .* collect(1:10) .+ shift
-        @test b.uhat(n) ≈ fill(value, 1, length(n))
+        n = 2 .* collect(1:10) .+ SparseIR.zeta(stat)
+        @test all(b.uhat(n) .≈ value)
     end
 
     @testset "LegendreBasis with stat = $stat" for stat in (fermion, boson)

--- a/test/freq.jl
+++ b/test/freq.jl
@@ -17,6 +17,10 @@ using SparseIR
 
     @test FermionicFreq(5) < BosonicFreq(6)
     @test BosonicFreq(6) >= BosonicFreq(6)
+
+    @test SparseIR.value(pioverbeta, 3) == π/3
+    @test SparseIR.valueim(2 * pioverbeta, 3) == 2im * π/3
+    @test_throws DomainError SparseIR.value(pioverbeta, -1)
 end
 
 @testset "freqadd" begin

--- a/test/freq.jl
+++ b/test/freq.jl
@@ -1,0 +1,42 @@
+using Test
+using SparseIR
+
+@testset "freq" begin
+
+@testset "freq" begin
+    @test SparseIR.zeta(MatsubaraFreq(2)) == 0
+    @test SparseIR.zeta(MatsubaraFreq(-5)) == 1
+
+    @test Integer(FermionicFreq(3)) == 3
+    @test Integer(BosonicFreq(-2)) == -2
+
+    @test Integer(MatsubaraFreq(Int32(4))) == 4
+
+    @test_throws ArgumentError FermionicFreq(4)
+    @test_throws ArgumentError BosonicFreq(-7)
+
+    @test FermionicFreq(5) < BosonicFreq(6)
+    @test BosonicFreq(6) >= BosonicFreq(6)
+end
+
+@testset "freqadd" begin
+    @test +pioverbeta == pioverbeta
+    @test iszero(pioverbeta - pioverbeta)
+
+    @test pioverbeta + oneunit(pioverbeta) == 2 * pioverbeta
+    @test Integer(4 * pioverbeta) == 4
+    @test Integer(pioverbeta - 2 * pioverbeta) == -1
+    @test iszero(zero(2 * pioverbeta))
+end
+
+@testset "freqrange" begin
+    @test length(FermionicFreq(1):FermionicFreq(-3)) == 0
+    @test length(FermionicFreq(3):FermionicFreq(200_000_000_001)) ==
+            100_000_000_000
+
+    @test collect(BosonicFreq(2):BosonicFreq(-2)) == []
+    @test collect(BosonicFreq(0):BosonicFreq(4)) == (0:2:4) .* pioverbeta
+    @test collect(FermionicFreq(-3):FermionicFreq(1)) == (-3:2:1) .* pioverbeta
+end
+
+end

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -52,7 +52,7 @@ using SparseIR
         u, s, v = sve_logistic[42]
         uhat = map(ui -> SparseIR.hat(ui, fermion), u)
 
-        n = [1, 3, 5, -1, -3, 5]
+        n = MatsubaraFreq.([1, 3, 5, -1, -3, 5])
         result1 = uhat[1](n)
         result = uhat(reshape(n, (3, 2)))
         result_iter = reshape(uhat(n), (:, 3, 2))

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -50,7 +50,7 @@ using SparseIR
 
     @testset "matrix_hat" begin
         u, s, v = sve_logistic[42]
-        uhat = SparseIR.hat.(u, :odd)
+        uhat = map(ui -> SparseIR.hat(ui, fermion), u)
 
         n = [1, 3, 5, -1, -3, 5]
         result1 = uhat[1](n)
@@ -80,7 +80,7 @@ using SparseIR
 
     @testset "eval unique" begin
         u, s, v = sve_logistic[42]
-        û = SparseIR.hat.(u, :odd)
+        û = map(ui -> SparseIR.hat(ui, fermion), u)
 
         # evaluate
         res1 = û([1, 3, 3, 1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("__conftest.jl")
 include("_util.jl")
 
 @testset verbose = true "SparseIR.jl" begin
+    include("freq.jl")
     include("gauss.jl")
     include("kernel.jl")
     include("poly.jl")

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -10,7 +10,6 @@ include("__conftest.jl")
         beta = 1
         wmax = 10
         basis = FiniteTempBasis(fermion, beta, wmax; sve_result=sve_logistic[beta * wmax])
-        @test MatsubaraSampling(basis) isa MatsubaraSampling64
         @test TauSampling(basis) isa TauSampling64
     end
 


### PR DESCRIPTION
This introduces the `Statistics` and `MatsubaraFreq{<: Statistics}` types, which allow for more expressiveness in that we don't need to pass integers around anymore and pretend they are frequencies.  It also allows for static type checking.

You may want to go though this commit-by-commit, since the PR is fairly large otherwise.