### PR TITLE
docs: add documentation for sampling_points

### DIFF
--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -169,6 +169,11 @@ function LinearAlgebra.cond(sampling::AbstractSampling)
     first(sampling.matrix_svd.S) / last(sampling.matrix_svd.S)
 end
 
+"""
+    sampling_points(sampling::AbstractSampling)
+
+Return sampling points.
+"""
 sampling_points(sampling::AbstractSampling) = sampling.sampling_points
 
 function Base.show(io::IO, ::MIME"text/plain", smpl::S) where {S<:AbstractSampling}


### PR DESCRIPTION
As the function is [part of the public API](https://github.com/SpM-lab/SparseIR.jl/blob/8cad759d614fbdeba92d245b98cd72b55609f5ed/src/SparseIR.jl#L14), I thought that it should have a docstring.