### PR TITLE
chore: ignore all Manifest files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 \#*\#
 
 *.ipynb
-Manifest.toml
+Manifest*.toml
 docs/Manifest.toml
 docs/build/
 playground_pluto.jl


### PR DESCRIPTION
Since Julia 1.11, different Manifest files can exist side-by-side for each minor version.