### PR TITLE
feat: reintroduce iscentrosymmetric function from v1.x.x

### DIFF
--- a/src/SparseIR.jl
+++ b/src/SparseIR.jl
@@ -13,6 +13,7 @@ export FiniteTempBasis, FiniteTempBasisSet
 export DiscreteLehmannRepresentation
 export overlap
 export LogisticKernel, RegularizedBoseKernel
+export iscentrosymmetric
 export AugmentedBasis, TauConst, TauLinear, MatsubaraConst
 export TauSampling, MatsubaraSampling, evaluate, fit, evaluate!, fit!,
        sampling_points, npoints

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -197,6 +197,17 @@ iswellconditioned(::AbstractBasis) = true
 
 ###############################################################################
 
+"""
+    iscentrosymmetric(kernel::AbstractKernel)
+
+Return whether the kernel satisfies `K(x, y) == K(-x, -y)` for all values of x and y.
+Defaults to `false`.
+
+A centrosymmetric kernel can be block-diagonalized, speeding up the singular value
+expansion by a factor of 4.
+"""
+iscentrosymmetric(::AbstractKernel) = false
+
 Base.broadcastable(kernel::AbstractKernel) = Ref(kernel)
 
 Base.broadcastable(sampling::AbstractSampling) = Ref(sampling)

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -67,3 +67,6 @@ end
 
 Λ(kernel::LogisticKernel) = kernel.Λ
 Λ(kernel::RegularizedBoseKernel) = kernel.Λ
+
+iscentrosymmetric(::LogisticKernel) = true
+iscentrosymmetric(::RegularizedBoseKernel) = true

--- a/test/spir/kernel_tests.jl
+++ b/test/spir/kernel_tests.jl
@@ -5,11 +5,13 @@
         lam = 42
         kernel = LogisticKernel(lam)
         @test SparseIR.Λ(kernel) == lam
+        @test iscentrosymmetric(kernel)
     end
 
     @testset "Regularized Bose kernel" begin
         lam = 42
         kernel = RegularizedBoseKernel(lam)
         @test SparseIR.Λ(kernel) == lam
+        @test iscentrosymmetric(kernel)
     end
 end


### PR DESCRIPTION
## Summary

Reintroduces the  function that was available in v1.x.x.

## Changes

- Added default  with docstring in 
- Specialized for  and  to return 
- Exported  function
- Added unit tests for 

## Testing

All tests pass (520 tests, 14 test items).

## Related

- Closes #93 (if applicable)