### PR TITLE
Improve build: use RustToolChain and selective imports

### DIFF
--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+RustToolChain = "e9dc52e2-edb8-4742-9783-5e542d30dbb5"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,6 @@
 using Pkg
 using Libdl: dlext
+using RustToolChain: cargo
 
 const DEV_DIR::String = joinpath(dirname(dirname(@__DIR__)), "sparse-ir-rs")
 
@@ -7,7 +8,7 @@ const DEV_DIR::String = joinpath(dirname(dirname(@__DIR__)), "sparse-ir-rs")
 # If it exists, build the Rust project and copy libsparse_ir_capi.<ext> to deps/.
 if isdir(DEV_DIR)
     cd(DEV_DIR) do
-        run(`cargo build --release --features system-blas`)
+        run(`$(cargo()) build --release --features system-blas`)
     end
     libsparseir_path = joinpath(DEV_DIR, "target", "release", "libsparse_ir_capi.$(dlext)")
     cp(libsparseir_path, joinpath(@__DIR__, "libsparse_ir_capi.$(dlext)"); force=true)

--- a/utils/generate_C_API.jl
+++ b/utils/generate_C_API.jl
@@ -2,8 +2,7 @@ using Pkg
 Pkg.activate(@__DIR__)
 Pkg.instantiate()
 
-using Clang.Generators
-using Clang.LibClang.Clang_jll
+using Clang.Generators: load_options, get_default_args, create_context, build!
 
 # Function to print help message
 function print_help()


### PR DESCRIPTION
## Summary
- **deps**: Add RustToolChain and use `cargo()` for cross-platform cargo lookup
- **utils**: Use selective imports in `generate_C_API.jl` instead of full module imports

Made with [Cursor](https://cursor.com)