### PR TITLE
Support on-the-fly Rust backend builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,15 @@ jobs:
             #os: windows-latest
             #arch: x64
     steps:
+      - name: Install OpenBLAS
+        run: |
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            sudo apt-get update
+            sudo apt-get install -y libopenblas-dev pkg-config gzip
+          fi
+          if [ "${{ matrix.os }}" = "macOS-latest" ]; then
+            brew install openblas pkg-config
+          fi
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
@@ -61,6 +70,10 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config gzip
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:

--- a/.github/workflows/CI_with_latest_rust_backend.yml
+++ b/.github/workflows/CI_with_latest_rust_backend.yml
@@ -81,6 +81,10 @@ jobs:
       group: docs-deploy
       cancel-in-progress: false
     steps:
+      - name: Install OpenBLAS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev pkg-config gzip
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ lcov.info
 !/.typos.toml
 
 deps/build.log
+deps/build-state.toml
+deps/backend.stamp
 deps/libsparse_ir_capi.*

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-libsparseir_jll = "e5bf0e3f-5e75-5bb8-9f3f-2c07620468a3"
 
 [compat]
 Aqua = "0.8.14"
@@ -19,16 +18,21 @@ LinearAlgebra = "1"
 QuadGK = "2.11.2"
 StableRNGs = "1.0.3"
 julia = "1.10"
-libsparseir_jll = "0.8.0"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [targets]
 dev = ["Clang"]
-test = ["Aqua", "Test", "ReTestItems", "Random", "StableRNGs"]
+test = ["Aqua", "Downloads", "Tar", "Test", "ReTestItems", "Random", "StableRNGs", "TOML"]
+
+[tool.sparseir]
+rust_backend_version = "0.8.1"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ intermediate representation of correlation functions. It provides:
 > Refer also to the accompanying paper:<br>
 > **[sparse-ir: Optimal compression and sparse sampling of many-body propagators](https://doi.org/10.1016/j.softx.2022.101266)**
 
-This is a Julia wrapper for the [libsparseir](https://github.com/SpM-lab/libsparseir) C library.
+This package uses the Rust `sparse-ir-capi` backend through its C API.
 
 Installation
 ------------
@@ -38,6 +38,9 @@ julia -e 'import Pkg; Pkg.develop(url="https://github.com/SpM-lab/SparseIR.jl")'
 ```
 > **Warning**
 > This is recommended only for developers - you won't get automatic updates!
+
+After `Pkg.develop(...)`, run `Pkg.build("SparseIR")` explicitly. Julia's
+`develop` workflow does not run package build steps automatically.
 
 You can also control debug output at runtime using the `SPARSEIR_DEBUG` environment variable:
 
@@ -133,6 +136,12 @@ terms of compactness.
 
 Development
 -----------
+SparseIR builds its Rust backend during `Pkg.build("SparseIR")`.
+Build source priority is:
+
+1. `../sparse-ir-rs` if that sibling checkout exists
+2. pinned `sparse-ir-capi` `0.8.1` from crates.io otherwise
+
 If you are developing `SparseIR.jl` together with the Rust backend in the sibling
 repository `../sparse-ir-rs`, rebuild this package after changing the Rust code:
 
@@ -141,13 +150,17 @@ julia -e 'using Pkg; Pkg.build()'
 ```
 
 This rebuilds the Rust backend, copies the generated shared library into `deps/`,
-and refreshes `src/C_API.jl`. See [`deps/README.md`](deps/README.md) for the
-developer-oriented build details.
+refreshes `src/C_API.jl`, and updates `deps/backend.stamp` so Julia invalidates
+stale precompile state automatically.
 
-If Julia still appears to load the artifact-provided library after `Pkg.build()`,
-the precompile cache may still be holding the old path. In that case, remove the
-compiled cache for `SparseIR` under `~/.julia/compiled/.../SparseIR` and start a
-fresh Julia process.
+Build-time environment variables:
+
+- `SPARSEIR_BUILD_DEBUG=1` keeps the temporary crates.io workspace after a successful build.
+- `SPARSEIR_BUILD_DEBUGINFO=none|line|full` controls the Rust debuginfo level embedded in the built library.
+
+Build progress is recorded in `deps/build-state.toml`, and detailed cargo/binding
+logs are written to `deps/build.log`. See [`deps/README.md`](deps/README.md) and
+[`development.md`](development.md) for the developer-oriented build details.
 
 License and citation
 --------------------

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -1,4 +1,7 @@
 [deps]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 RustToolChain = "e9dc52e2-edb8-4742-9783-5e542d30dbb5"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/deps/README.md
+++ b/deps/README.md
@@ -1,19 +1,37 @@
 # deps
 
-The `build.jl` script provides developer-focused support for building the Rust backend required by `SparseIR.jl`. It assumes that the Rust crate `sparse-ir-rs` is located in the same parent directory as the `SparseIR.jl` package.
+`Pkg.build("SparseIR")` builds the Rust backend used by `SparseIR.jl` and writes
+the runtime artifacts into `deps/`.
 
-After making changes to the Rust code, it is assumed that you will rebuild the Julia package as follows:
+Build source priority:
 
+1. use a sibling checkout at `../sparse-ir-rs` when it exists
+2. otherwise download pinned `sparse-ir-capi` `0.8.1` from crates.io and build it in a temporary workspace
+
+After a successful build, the script:
+
+- copies `libsparse_ir_capi.(dylib|so|dll)` into `deps/`
+- regenerates `src/C_API.jl`
+- updates `deps/backend.stamp`
+- records build status in `deps/build-state.toml`
+- writes detailed logs to `deps/build.log`
+
+Build-time environment variables:
+
+- `SPARSEIR_BUILD_DEBUG=1`
+  Keeps the temporary crates.io workspace after a successful build. Failed builds
+  always keep the workspace path recorded in `deps/build-state.toml`.
+- `SPARSEIR_BUILD_DEBUGINFO=none|line|full`
+  Controls the Rust debuginfo level passed to cargo.
+
+Examples:
+
+```bash
+julia -e 'using Pkg; Pkg.build("SparseIR")'
+SPARSEIR_BUILD_DEBUG=1 julia -e 'using Pkg; Pkg.build("SparseIR")'
+SPARSEIR_BUILD_DEBUGINFO=full julia -e 'using Pkg; Pkg.build("SparseIR")'
 ```
-$ cd path/to/SparseIR.jl
-$ ls
-src/ utils/ test/ ...
-$ julia -e 'using Pkg; Pkg.build()'
-```
 
-This process will update `src/C_API.jl` and copy the `libsparse_ir_capi.dylib` (or the appropriate shared library) to the `deps/` directory. During `Pkg.test()`, the dynamic library `deps/libsparse_ir_capi.[dylib|so]` will be linked.
-
-If `Pkg.build()` finishes successfully but Julia still loads the artifact-provided
-library instead of `deps/libsparse_ir_capi.[dylib|so]`, the cause may be Julia's
-precompile cache. In that case, remove the compiled cache for `SparseIR` under
-`~/.julia/compiled/.../SparseIR` and start a fresh Julia process before testing again.
+`Pkg.add("SparseIR")` runs the build step automatically on first install.
+`Pkg.develop(...)` does not, so development checkouts must run
+`Pkg.build("SparseIR")` explicitly.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,19 +1,6 @@
-using Pkg
-using Libdl: dlext
 using RustToolChain: cargo
 
-const DEV_DIR::String = joinpath(dirname(dirname(@__DIR__)), "sparse-ir-rs")
+include("build_support.jl")
+using .BuildSupport
 
-# Check if the sparse-ir-rs directory exists locally; if not, do nothing.
-# If it exists, build the Rust project and copy libsparse_ir_capi.<ext> to deps/.
-if isdir(DEV_DIR)
-    cd(DEV_DIR) do
-        run(`$(cargo()) build --release --features system-blas`)
-    end
-    libsparseir_path = joinpath(DEV_DIR, "target", "release", "libsparse_ir_capi.$(dlext)")
-    cp(libsparseir_path, joinpath(@__DIR__, "libsparse_ir_capi.$(dlext)"); force=true)
-
-    cd(joinpath(dirname(@__DIR__), "utils")) do
-        run(`$(Base.julia_cmd()) --project generate_C_API.jl`)
-    end
-end
+BuildSupport.main(; cargo_cmd=cargo())

--- a/deps/build_support.jl
+++ b/deps/build_support.jl
@@ -1,0 +1,281 @@
+module BuildSupport
+
+using Downloads: Downloads
+using Libdl: dlext
+using Tar: Tar
+using TOML: TOML
+
+const LIBSPARSEIR_FILENAME = "libsparse_ir_capi.$(dlext)"
+
+function parse_keep_workdir(env::AbstractDict)
+    return get(env, "SPARSEIR_BUILD_DEBUG", "0") == "1"
+end
+
+function parse_debuginfo(env::AbstractDict)
+    value = get(env, "SPARSEIR_BUILD_DEBUGINFO", "none")
+    mapping = Dict(
+        "none" => "none",
+        "line" => "line-tables-only",
+        "full" => "full",
+    )
+    haskey(mapping, value) || error("Unsupported SPARSEIR_BUILD_DEBUGINFO=$value")
+    return mapping[value]
+end
+
+backend_stamp_path(root::AbstractString) = joinpath(root, "deps", "backend.stamp")
+build_state_path(root::AbstractString) = joinpath(root, "deps", "build-state.toml")
+build_log_path(root::AbstractString) = joinpath(root, "deps", "build.log")
+installed_library_path(root::AbstractString) = joinpath(root, "deps", LIBSPARSEIR_FILENAME)
+
+function read_backend_version(project_toml::AbstractString)
+    data = TOML.parsefile(project_toml)
+    return data["tool"]["sparseir"]["rust_backend_version"]
+end
+
+function write_build_state!(
+    root::AbstractString;
+    phase,
+    mode,
+    workspace,
+    debug,
+    keep_workdir,
+)
+    mkpath(joinpath(root, "deps"))
+    open(build_state_path(root), "w") do io
+        TOML.print(io, Dict(
+            "phase" => phase,
+            "mode" => mode,
+            "workspace" => something(workspace, ""),
+            "debug" => debug,
+            "keep_workdir" => keep_workdir,
+        ))
+    end
+end
+
+function build_state_snapshot(plan; phase)
+    return (
+        phase=phase,
+        mode=plan.mode,
+        workspace=plan.workspace,
+        debug=plan.debug,
+        keep_workdir=plan.keep_workdir,
+    )
+end
+
+function write_phase!(plan; phase)
+    write_build_state!(
+        plan.root;
+        build_state_snapshot(plan; phase)...,
+    )
+end
+
+function write_backend_stamp!(
+    root::AbstractString;
+    source,
+    workspace,
+    version,
+)
+    mkpath(joinpath(root, "deps"))
+    open(backend_stamp_path(root), "w") do io
+        TOML.print(io, Dict(
+            "source" => string(source),
+            "workspace" => workspace,
+            "version" => version,
+            "timestamp" => string(time()),
+        ))
+    end
+end
+
+function select_build_source(
+    root::AbstractString;
+    dev_dir::AbstractString=joinpath(dirname(root), "sparse-ir-rs"),
+)
+    if isdir(dev_dir)
+        return (kind=:local, workspace=dev_dir)
+    end
+    return (kind=:crates_io, workspace=nothing)
+end
+
+function build_plan(
+    root::AbstractString;
+    env::AbstractDict=ENV,
+    dev_dir::AbstractString=joinpath(dirname(root), "sparse-ir-rs"),
+)
+    source = select_build_source(root; dev_dir)
+    keep_workdir = parse_keep_workdir(env)
+    return (
+        root=root,
+        source=source.kind,
+        workspace=source.workspace,
+        version=read_backend_version(joinpath(root, "Project.toml")),
+        keep_workdir=keep_workdir,
+        debug=keep_workdir,
+        debuginfo=parse_debuginfo(env),
+        mode="release",
+    )
+end
+
+crates_io_download_url(version::AbstractString) =
+    "https://crates.io/api/v1/crates/sparse-ir-capi/$version/download"
+
+rustflags(plan) = "-C debuginfo=$(plan.debuginfo)"
+
+function stamp_source(plan)
+    if plan.source == :local
+        return "local-checkout"
+    end
+    return "crates-io"
+end
+
+function crate_dir(plan)
+    if plan.source == :local
+        return joinpath(plan.workspace, "sparse-ir-capi")
+    end
+    return joinpath(plan.workspace, "sparse-ir-capi-$(plan.version)")
+end
+
+function build_workdir(plan)
+    if plan.source == :local
+        return plan.workspace
+    end
+    return crate_dir(plan)
+end
+
+function built_library_path(plan)
+    if plan.source == :local
+        return joinpath(plan.workspace, "target", plan.mode, LIBSPARSEIR_FILENAME)
+    end
+    return joinpath(crate_dir(plan), "target", plan.mode, LIBSPARSEIR_FILENAME)
+end
+
+function copy_backend_library!(plan)
+    source = built_library_path(plan)
+    isfile(source) || error("SparseIR backend library not found at $source")
+
+    destination = installed_library_path(plan.root)
+    mkpath(dirname(destination))
+    cp(source, destination; force=true)
+    return destination
+end
+
+function cargo_build_cmd(plan, cargo_cmd::Cmd)
+    return addenv(
+        `$(cargo_cmd) build --manifest-path $(joinpath(crate_dir(plan), "Cargo.toml")) --release --features system-blas`,
+        "RUSTFLAGS" => rustflags(plan),
+    )
+end
+
+function gunzip_cmd(archive::AbstractString)
+    gzip = Sys.which("gzip")
+    gzip === nothing && error("gzip executable is required to extract crates.io sources")
+    return `$gzip -dc $archive`
+end
+
+function prepare_workspace!(plan, log_io::IO)
+    if plan.source == :local
+        return plan
+    end
+
+    workspace = mktempdir(; cleanup=false)
+    archive, archive_io = mktemp()
+    close(archive_io)
+    url = crates_io_download_url(plan.version)
+    try
+        println(log_io, "Downloading crates.io source: $url")
+        Downloads.download(url, archive)
+        println(log_io, "Extracting crates.io source into $workspace")
+        Tar.extract(gunzip_cmd(archive), workspace)
+    finally
+        rm(archive; force=true)
+    end
+    return merge(plan, (workspace=workspace,))
+end
+
+function regenerate_c_api!(plan, log_io::IO)
+    utils_dir = joinpath(plan.root, "utils")
+    command = `$(Base.julia_cmd()) --project=. generate_C_API.jl --libsparseir-dir $(crate_dir(plan))`
+    println(log_io, "Regenerating Julia C API bindings in $utils_dir")
+    cd(utils_dir) do
+        run(pipeline(command; stdout=log_io, stderr=log_io))
+    end
+end
+
+function run_backend_build!(plan, log_io::IO; cargo_cmd::Cmd)
+    command = cargo_build_cmd(plan, cargo_cmd)
+    println(log_io, "Running build command in $(build_workdir(plan))")
+    println(log_io, command)
+    cd(build_workdir(plan)) do
+        run(pipeline(command; stdout=log_io, stderr=log_io))
+    end
+    return built_library_path(plan)
+end
+
+function cleanup_workspace!(plan; success::Bool)
+    if plan.source == :crates_io && plan.workspace !== nothing && success && !plan.keep_workdir
+        rm(plan.workspace; recursive=true, force=true)
+    end
+    return nothing
+end
+
+function build_phase(plan)
+    if plan.source == :local
+        return "building-local-checkout"
+    end
+    return "building-from-crates-io"
+end
+
+function failure_message(root::AbstractString, workspace)
+    message = "SparseIR backend build failed. See $(build_log_path(root)) and $(build_state_path(root))."
+    if workspace !== nothing
+        message *= " Workspace: $workspace."
+    end
+    return message
+end
+
+function main(; root::AbstractString=dirname(@__DIR__), env::AbstractDict=ENV, cargo_cmd::Cmd)
+    plan = build_plan(root; env)
+    success = false
+    mkpath(joinpath(root, "deps"))
+
+    open(build_log_path(root), "w") do log_io
+        println(log_io, "SparseIR backend build")
+        println(log_io, "source = $(plan.source)")
+        println(log_io, "version = $(plan.version)")
+        println(log_io, "debug = $(plan.debug)")
+        println(log_io, "keep_workdir = $(plan.keep_workdir)")
+        println(log_io)
+        write_phase!(plan; phase=plan.source == :local ? "using-local-checkout" : "fetching-crates-io")
+
+        try
+            plan = prepare_workspace!(plan, log_io)
+            write_phase!(plan; phase=build_phase(plan))
+
+            run_backend_build!(plan, log_io; cargo_cmd)
+            copy_backend_library!(plan)
+
+            write_phase!(plan; phase="regenerating-c-api")
+            regenerate_c_api!(plan, log_io)
+
+            write_backend_stamp!(
+                root;
+                source=stamp_source(plan),
+                workspace=something(plan.workspace, ""),
+                version=plan.version,
+            )
+            write_phase!(plan; phase="success")
+            success = true
+        catch err
+            write_phase!(plan; phase="failed")
+            println(log_io)
+            showerror(log_io, err, catch_backtrace())
+            println(log_io)
+            error(failure_message(root, plan.workspace))
+        finally
+            cleanup_workspace!(plan; success)
+        end
+    end
+
+    return nothing
+end
+
+end

--- a/development.md
+++ b/development.md
@@ -27,9 +27,9 @@ using Documenter
 include("docs/make.jl")
 ```
 
-### Using Local libsparseir for Development
+### Rust Backend Development
 
-During development, you may want to use a locally built version of `libsparseir` instead of the pre-built JLL package. This allows you to test changes to the C API immediately.
+SparseIR now builds its Rust backend during `Pkg.build("SparseIR")`.
 
 **Directory Structure:**
 ```
@@ -39,100 +39,54 @@ projects/
 │   └── SparseIR.jl/       # Julia bindings
 ```
 
-**Steps:**
+**Build source priority:**
 
-1. **Place repositories side by side**: Ensure `sparse-ir-rs` and `SparseIR.jl` are in the same parent directory.
+1. `../sparse-ir-rs` if the sibling checkout exists
+2. pinned `sparse-ir-capi` `0.8.1` from crates.io otherwise
 
-2. **Rebuild SparseIR.jl**: The build script automatically detects `sparse-ir-rs` and builds it:
-   ```julia
-   using Pkg
-   Pkg.build("SparseIR")
-   ```
+**Important:** `Pkg.add("SparseIR")` runs the build step automatically on first
+install, but `Pkg.develop(...)` does not. For development checkouts, run:
 
-   This will:
-   - Detect `../sparse-ir-rs` directory
-   - Build `sparse-ir-rs` with `cargo build --release --features system-blas`
-   - Copy `libsparse_ir_capi.dylib` (or `.so`/`.dll`) to `deps/`
-   - Regenerate C API bindings in `src/C_API.jl`
-
-3. **Verify the build**: Check that the local library was built:
-   ```bash
-   ls -lh deps/libsparse_ir_capi.dylib
-   ```
-
-4. **Test with local library**:
-   ```julia
-   using SparseIR
-   basis = FiniteTempBasis{Fermionic}(10.0, 1.0, 1e-6)
-   println("Basis size: ", length(basis))
-   ```
-
-**Note:** If `sparse-ir-rs` is not found in the expected location, SparseIR.jl will fall back to using the pre-built `libsparseir_jll` package from Julia's package registry.
-
-### Switching Between Local and Remote libsparseir
-
-**Using Local libsparseir (for development):**
-
-When `deps/libsparse_ir_capi.dylib` (or `.so`/`.dll`) exists, SparseIR.jl will use it automatically. You'll see:
-```
-[ Info: Using local libsparseir: /path/to/SparseIR.jl/deps/libsparse_ir_capi.dylib
+```julia
+using Pkg
+Pkg.build("SparseIR")
 ```
 
-**Switching to Remote libsparseir (JLL version):**
+This build step:
 
-To use the pre-built JLL package instead of the local library:
+- builds the Rust backend with `cargo build --release --features system-blas`
+- copies `libsparse_ir_capi.(dylib|so|dll)` into `deps/`
+- regenerates `src/C_API.jl`
+- updates `deps/backend.stamp` so backend rebuilds invalidate Julia precompile state
+- records progress in `deps/build-state.toml`
+- writes detailed logs to `deps/build.log`
+
+**Build-time environment variables:**
+
+- `SPARSEIR_BUILD_DEBUG=1`
+  Keeps the temporary crates.io workspace after a successful build. Failed builds
+  also keep the workspace path for inspection.
+- `SPARSEIR_BUILD_DEBUGINFO=none|line|full`
+  Controls the debuginfo level embedded in the Rust library.
+
+**Examples:**
 
 ```bash
-# Remove local library
-rm -rf deps/libsparse_ir_capi.*
-
-# Clear precompilation cache
-rm -rf ~/.julia/compiled/v1.*/SparseIR/
-
-# Restart Julia and verify
-julia --project=. -e "using SparseIR"
-# You should NOT see the "Using local libsparseir" message
+julia --project=. -e 'using Pkg; Pkg.build("SparseIR")'
+SPARSEIR_BUILD_DEBUG=1 julia --project=. -e 'using Pkg; Pkg.build("SparseIR")'
+SPARSEIR_BUILD_DEBUGINFO=full julia --project=. -e 'using Pkg; Pkg.build("SparseIR")'
 ```
 
-**Switching back to Local libsparseir:**
+**Build diagnostics:**
 
 ```bash
-# Rebuild local library
-julia --project=. -e "using Pkg; Pkg.build(\"SparseIR\")"
-
-# Clear precompilation cache
-rm -rf ~/.julia/compiled/v1.*/SparseIR/
-
-# Restart Julia and verify
-julia --project=. -e "using SparseIR"
-# You should see "Using local libsparseir: ..." message
+cat deps/build-state.toml
+tail -n 50 deps/build.log
 ```
 
-### Clearing Build Cache
-
-If you need to force a clean rebuild (e.g., after updating `sparse-ir-rs`):
-
-```bash
-# Remove the built library and cached files
-rm -rf deps/libsparse_ir_capi.*
-rm -rf deps/build.log
-
-# Then rebuild
-julia --project=. -e "using Pkg; Pkg.build(\"SparseIR\")"
-```
-
-For a complete clean rebuild:
-
-```bash
-# 1. Clean local build artifacts
-rm -rf deps/
-
-# 2. Clear precompilation cache
-rm -rf ~/.julia/compiled/v1.*/SparseIR/
-
-# 3. Rebuild and precompile
-julia --project=. -e "using Pkg; Pkg.build(\"SparseIR\"); using SparseIR"
-```
+Manual precompile-cache deletion should normally not be necessary. Backend
+rebuilds update `deps/backend.stamp`, and `src/C_API.jl` tracks that file as a
+precompile dependency.
 
 ## Code Structure
 
@@ -241,4 +195,3 @@ Profile.print()
 3. Ensure all tests pass
 4. Build documentation
 5. Create and push a tag
-

--- a/src/C_API.jl
+++ b/src/C_API.jl
@@ -2,21 +2,15 @@ module C_API
 
 using CEnum: CEnum, @cenum
 
-using Libdl: Libdl
-using libsparseir_jll: libsparseir_jll
+include("backend_loader.jl")
+using .BackendLoader
 
-function get_libsparseir()
-    deps_dir = joinpath(dirname(@__DIR__), "deps")
-    local_libsparseir_path = joinpath(deps_dir, "libsparse_ir_capi.$(Libdl.dlext)")
-    if isfile(local_libsparseir_path)
-        @info "Using local libsparseir: $local_libsparseir_path"
-        return local_libsparseir_path
-    else
-        return libsparseir_jll.libsparseir
-    end
+const _backend_stamp = BackendLoader.backend_stamp_path()
+if isfile(_backend_stamp)
+    Base.include_dependency(_backend_stamp)
 end
 
-const libsparseir = get_libsparseir()
+const libsparseir = BackendLoader.require_backend_library()
 
 
 """

--- a/src/SparseIR.jl
+++ b/src/SparseIR.jl
@@ -23,7 +23,6 @@ function _is_column_major_contiguous(A::AbstractArray)
     strides(A) == cumprod((1, size(A)...)[1:(end - 1)])
 end
 
-import libsparseir_jll
 # From Julia, an "opaque pointer" is sufficient to represent the backend
 const SpirGemmBackend = Ptr{Cvoid}
 

--- a/src/backend_loader.jl
+++ b/src/backend_loader.jl
@@ -1,0 +1,15 @@
+module BackendLoader
+
+using Libdl: dlext
+
+deps_dir(root::AbstractString=dirname(@__DIR__)) = joinpath(root, "deps")
+backend_stamp_path(root::AbstractString=dirname(@__DIR__)) = joinpath(deps_dir(root), "backend.stamp")
+backend_library_path(root::AbstractString=dirname(@__DIR__)) = joinpath(deps_dir(root), "libsparse_ir_capi.$(dlext)")
+
+function require_backend_library(root::AbstractString=dirname(@__DIR__))
+    libpath = backend_library_path(root)
+    isfile(libpath) || error("SparseIR backend not found at $libpath. Run `Pkg.build(\"SparseIR\")`.")
+    return libpath
+end
+
+end

--- a/test/backend_loader_tests.jl
+++ b/test/backend_loader_tests.jl
@@ -1,0 +1,22 @@
+@testitem "backend loader" tags=[:julia] begin
+    using Libdl: dlext
+    using Test
+
+    include(joinpath(dirname(@__DIR__), "src", "backend_loader.jl"))
+    using .BackendLoader
+
+    mktempdir() do root
+        err = @test_throws ErrorException BackendLoader.require_backend_library(root)
+        @test occursin("Pkg.build(\"SparseIR\")", sprint(showerror, err.value))
+    end
+
+    mktempdir() do root
+        deps_dir = joinpath(root, "deps")
+        mkpath(deps_dir)
+        libpath = joinpath(deps_dir, "libsparse_ir_capi.$(dlext)")
+        write(libpath, "")
+        @test BackendLoader.backend_stamp_path(root) == joinpath(root, "deps", "backend.stamp")
+        @test BackendLoader.backend_library_path(root) == libpath
+        @test BackendLoader.require_backend_library(root) == libpath
+    end
+end

--- a/test/build_support_tests.jl
+++ b/test/build_support_tests.jl
@@ -1,0 +1,173 @@
+@testitem "build support parsing" tags=[:build, :julia] begin
+    using Test
+    using TOML
+    using Libdl: dlext
+
+    include(joinpath(dirname(@__DIR__), "deps", "build_support.jl"))
+    using .BuildSupport
+
+    repo_root = dirname(@__DIR__)
+    expected_version = BuildSupport.read_backend_version(joinpath(repo_root, "Project.toml"))
+
+    @test BuildSupport.parse_keep_workdir(Dict("SPARSEIR_BUILD_DEBUG" => "1")) === true
+    @test BuildSupport.parse_keep_workdir(Dict{String,String}()) === false
+    @test BuildSupport.parse_debuginfo(Dict("SPARSEIR_BUILD_DEBUGINFO" => "line")) == "line-tables-only"
+
+    mktempdir() do root
+        mkpath(joinpath(root, "deps"))
+        @test BuildSupport.backend_stamp_path(root) == joinpath(root, "deps", "backend.stamp")
+        @test BuildSupport.select_build_source(root; dev_dir=joinpath(root, "..", "sparse-ir-rs")).kind == :crates_io
+    end
+
+    mktempdir() do root
+        project_toml = joinpath(root, "Project.toml")
+        write(project_toml, """
+        [tool.sparseir]
+        rust_backend_version = "$expected_version"
+        """)
+        @test BuildSupport.read_backend_version(project_toml) == expected_version
+
+        BuildSupport.write_build_state!(
+            root;
+            phase="building-from-crates-io",
+            mode="release",
+            workspace="/tmp/work",
+            debug=false,
+            keep_workdir=false,
+        )
+        state = TOML.parsefile(BuildSupport.build_state_path(root))
+        @test state["phase"] == "building-from-crates-io"
+        @test state["mode"] == "release"
+        @test state["workspace"] == "/tmp/work"
+        @test state["debug"] == false
+        @test state["keep_workdir"] == false
+
+        BuildSupport.write_backend_stamp!(
+            root;
+            source="crates-io",
+            workspace="/tmp/work",
+            version=expected_version,
+        )
+        stamp = TOML.parsefile(BuildSupport.backend_stamp_path(root))
+        @test stamp["source"] == "crates-io"
+        @test stamp["workspace"] == "/tmp/work"
+        @test stamp["version"] == expected_version
+        @test haskey(stamp, "timestamp")
+    end
+
+    @test expected_version == BuildSupport.read_backend_version(joinpath(repo_root, "Project.toml"))
+
+    mktempdir() do root
+        write(joinpath(root, "Project.toml"), """
+        [tool.sparseir]
+        rust_backend_version = "$expected_version"
+        """)
+        dev_dir = joinpath(root, "sparse-ir-rs")
+        mkpath(dev_dir)
+        plan = BuildSupport.build_plan(root; env=Dict{String,String}(), dev_dir=dev_dir)
+        @test plan.source == :local
+        @test plan.workspace == dev_dir
+        @test plan.version == expected_version
+        @test plan.keep_workdir == false
+        @test plan.debuginfo == "none"
+    end
+
+    mktempdir() do root
+        write(joinpath(root, "Project.toml"), """
+        [tool.sparseir]
+        rust_backend_version = "$expected_version"
+        """)
+        plan = BuildSupport.build_plan(
+            root;
+            env=Dict(
+                "SPARSEIR_BUILD_DEBUG" => "1",
+                "SPARSEIR_BUILD_DEBUGINFO" => "full",
+            ),
+            dev_dir=joinpath(root, "missing"),
+        )
+        @test plan.source == :crates_io
+        @test plan.workspace === nothing
+        @test plan.version == expected_version
+        @test plan.keep_workdir == true
+        @test plan.debuginfo == "full"
+    end
+
+    @test BuildSupport.crates_io_download_url(expected_version) ==
+        "https://crates.io/api/v1/crates/sparse-ir-capi/$expected_version/download"
+
+    local_plan = (
+        root="/tmp/root",
+        source=:local,
+        workspace="/tmp/dev",
+        version=expected_version,
+        keep_workdir=false,
+        debug=false,
+        debuginfo="line-tables-only",
+        mode="release",
+    )
+    @test BuildSupport.crate_dir(local_plan) == joinpath("/tmp/dev", "sparse-ir-capi")
+    @test BuildSupport.rustflags(local_plan) == "-C debuginfo=line-tables-only"
+    @test BuildSupport.stamp_source(local_plan) == "local-checkout"
+
+    crates_plan = (
+        root="/tmp/root",
+        source=:crates_io,
+        workspace="/tmp/work",
+        version=expected_version,
+        keep_workdir=true,
+        debug=true,
+        debuginfo="full",
+        mode="release",
+    )
+    @test BuildSupport.crate_dir(crates_plan) == joinpath("/tmp/work", "sparse-ir-capi-$expected_version")
+    @test BuildSupport.rustflags(crates_plan) == "-C debuginfo=full"
+    @test BuildSupport.stamp_source(crates_plan) == "crates-io"
+    @test BuildSupport.build_workdir(local_plan) == "/tmp/dev"
+    @test BuildSupport.build_workdir(crates_plan) == joinpath("/tmp/work", "sparse-ir-capi-$expected_version")
+    @test BuildSupport.installed_library_path("/tmp/root") ==
+        joinpath("/tmp/root", "deps", "libsparse_ir_capi.$(dlext)")
+    @test BuildSupport.built_library_path(local_plan) ==
+        joinpath("/tmp/dev", "target", "release", "libsparse_ir_capi.$(dlext)")
+    @test BuildSupport.built_library_path(crates_plan) ==
+        joinpath("/tmp/work", "sparse-ir-capi-$expected_version", "target", "release", "libsparse_ir_capi.$(dlext)")
+
+    mktempdir() do root
+        workspace = joinpath(root, "work")
+        plan = (
+            root=root,
+            source=:crates_io,
+            workspace=workspace,
+            version=expected_version,
+            keep_workdir=false,
+            debug=false,
+            debuginfo="none",
+            mode="release",
+        )
+        libpath = BuildSupport.built_library_path(plan)
+        mkpath(dirname(libpath))
+        write(libpath, "stub")
+        copied_path = BuildSupport.copy_backend_library!(plan)
+        @test copied_path == BuildSupport.installed_library_path(root)
+        @test read(copied_path, String) == "stub"
+    end
+
+    mktempdir() do root
+        plan = (
+            root=root,
+            source=:crates_io,
+            workspace="/tmp/work",
+            version=expected_version,
+            keep_workdir=true,
+            debug=true,
+            debuginfo="full",
+            mode="release",
+        )
+        BuildSupport.write_phase!(plan; phase="success")
+        state = TOML.parsefile(BuildSupport.build_state_path(root))
+        @test state["phase"] == "success"
+        @test state["mode"] == "release"
+        @test state["workspace"] == "/tmp/work"
+        @test state["debug"] == true
+        @test state["keep_workdir"] == true
+    end
+end

--- a/utils/prologue.jl
+++ b/utils/prologue.jl
@@ -1,15 +1,9 @@
-using Libdl: Libdl
-using libsparseir_jll: libsparseir_jll
+include("backend_loader.jl")
+using .BackendLoader
 
-function get_libsparseir()
-    deps_dir = joinpath(dirname(@__DIR__), "deps")
-    local_libsparseir_path = joinpath(deps_dir, "libsparse_ir_capi.$(Libdl.dlext)")
-    if isfile(local_libsparseir_path)
-        @info "Using local libsparseir: $local_libsparseir_path"
-        return local_libsparseir_path
-    else
-        return libsparseir_jll.libsparseir
-    end
+const _backend_stamp = BackendLoader.backend_stamp_path()
+if isfile(_backend_stamp)
+    Base.include_dependency(_backend_stamp)
 end
 
-const libsparseir = get_libsparseir()
+const libsparseir = BackendLoader.require_backend_library()


### PR DESCRIPTION
## Summary
- replace the runtime JLL fallback with an on-the-fly Rust backend build flow that prefers `../sparse-ir-rs` and falls back to crates.io `sparse-ir-capi` `0.8.1`
- track backend rebuilds via `deps/backend.stamp`, expose build diagnostics in `deps/build-state.toml` and `deps/build.log`, and add focused tests for build/runtime loader behavior
- document the new build contract and update CI so the default path exercises crates.io builds while the sibling-checkout workflow still covers local backend builds

## Test Plan
- [x] `julia --project=. -e 'using Pkg; Pkg.build()'`
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'`
- [x] `julia --project=. -e 'using SparseIR'`
- [x] `SPARSEIR_BUILD_DEBUG=1 julia --project=. -e 'using Pkg; Pkg.build()'`
- [x] `SPARSEIR_BUILD_DEBUGINFO=line julia --project=. -e 'using Pkg; Pkg.build()'`
- [x] `SPARSEIR_BUILD_DEBUGINFO=full julia --project=. -e 'using Pkg; Pkg.build()'`
