### PR TITLE
feat: make local rust backend checkout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,16 @@ Development
 SparseIR builds its Rust backend during `Pkg.build("SparseIR")`.
 Build source priority is:
 
-1. `../sparse-ir-rs` if that sibling checkout exists
-2. pinned `sparse-ir-capi` `0.8.1` from crates.io otherwise
+1. `SPARSEIR_RUST_BACKEND_DIR` when set; relative paths are resolved against the `SparseIR.jl` package root
+2. `../sparse-ir-rs` if that sibling checkout exists
+3. pinned `sparse-ir-capi` `0.8.1` from crates.io otherwise
 
-If you are developing `SparseIR.jl` together with the Rust backend in the sibling
-repository `../sparse-ir-rs`, rebuild this package after changing the Rust code:
+If you are developing `SparseIR.jl` together with the Rust backend in another
+worktree or checkout, point `SPARSEIR_RUST_BACKEND_DIR` at that repository and
+rebuild this package after changing the Rust code:
 
 ```bash
+export SPARSEIR_RUST_BACKEND_DIR=/path/to/sparse-ir-rs
 julia -e 'using Pkg; Pkg.build()'
 ```
 
@@ -155,6 +158,9 @@ stale precompile state automatically.
 
 Build-time environment variables:
 
+- `SPARSEIR_RUST_BACKEND_DIR=/path/to/sparse-ir-rs`
+  Selects a local Rust backend checkout. Relative paths are resolved against
+  the `SparseIR.jl` package root.
 - `SPARSEIR_BUILD_DEBUG=1` keeps the temporary crates.io workspace after a successful build.
 - `SPARSEIR_BUILD_DEBUGINFO=none|line|full` controls the Rust debuginfo level embedded in the built library.
 

--- a/deps/README.md
+++ b/deps/README.md
@@ -5,8 +5,12 @@ the runtime artifacts into `deps/`.
 
 Build source priority:
 
-1. use a sibling checkout at `../sparse-ir-rs` when it exists
-2. otherwise download pinned `sparse-ir-capi` `0.8.1` from crates.io and build it in a temporary workspace
+1. use `SPARSEIR_RUST_BACKEND_DIR` when it is set and points to an existing checkout
+2. otherwise use a sibling checkout at `../sparse-ir-rs` when it exists
+3. otherwise download pinned `sparse-ir-capi` `0.8.1` from crates.io and build it in a temporary workspace
+
+Relative paths in `SPARSEIR_RUST_BACKEND_DIR` are resolved against the
+`SparseIR.jl` package root.
 
 After a successful build, the script:
 
@@ -18,6 +22,8 @@ After a successful build, the script:
 
 Build-time environment variables:
 
+- `SPARSEIR_RUST_BACKEND_DIR=/path/to/sparse-ir-rs`
+  Selects a local Rust backend checkout before the sibling default is checked.
 - `SPARSEIR_BUILD_DEBUG=1`
   Keeps the temporary crates.io workspace after a successful build. Failed builds
   always keep the workspace path recorded in `deps/build-state.toml`.

--- a/deps/build_support.jl
+++ b/deps/build_support.jl
@@ -6,6 +6,7 @@ using Tar: Tar
 using TOML: TOML
 
 const LIBSPARSEIR_FILENAME = "libsparse_ir_capi.$(dlext)"
+const LOCAL_RUST_BACKEND_DIR_ENV = "SPARSEIR_RUST_BACKEND_DIR"
 
 function parse_keep_workdir(env::AbstractDict)
     return get(env, "SPARSEIR_BUILD_DEBUG", "0") == "1"
@@ -30,6 +31,12 @@ installed_library_path(root::AbstractString) = joinpath(root, "deps", LIBSPARSEI
 function read_backend_version(project_toml::AbstractString)
     data = TOML.parsefile(project_toml)
     return data["tool"]["sparseir"]["rust_backend_version"]
+end
+
+function normalize_local_backend_dir(root::AbstractString, backend_dir::AbstractString)
+    path = expanduser(strip(backend_dir))
+    isempty(path) && error("$LOCAL_RUST_BACKEND_DIR_ENV is set but empty")
+    return isabspath(path) ? normpath(path) : normpath(joinpath(root, path))
 end
 
 function write_build_state!(
@@ -86,12 +93,32 @@ function write_backend_stamp!(
     end
 end
 
-function select_build_source(
+function resolve_local_backend_dir(
     root::AbstractString;
+    env::AbstractDict=ENV,
     dev_dir::AbstractString=joinpath(dirname(root), "sparse-ir-rs"),
 )
+    if haskey(env, LOCAL_RUST_BACKEND_DIR_ENV)
+        dir = normalize_local_backend_dir(root, env[LOCAL_RUST_BACKEND_DIR_ENV])
+        isdir(dir) || error("$LOCAL_RUST_BACKEND_DIR_ENV points to a missing directory: $dir")
+        return dir
+    end
+
     if isdir(dev_dir)
-        return (kind=:local, workspace=dev_dir)
+        return dev_dir
+    end
+
+    return nothing
+end
+
+function select_build_source(
+    root::AbstractString;
+    env::AbstractDict=ENV,
+    dev_dir::AbstractString=joinpath(dirname(root), "sparse-ir-rs"),
+)
+    local_dir = resolve_local_backend_dir(root; env, dev_dir)
+    if local_dir !== nothing
+        return (kind=:local, workspace=local_dir)
     end
     return (kind=:crates_io, workspace=nothing)
 end
@@ -101,7 +128,7 @@ function build_plan(
     env::AbstractDict=ENV,
     dev_dir::AbstractString=joinpath(dirname(root), "sparse-ir-rs"),
 )
-    source = select_build_source(root; dev_dir)
+    source = select_build_source(root; env, dev_dir)
     keep_workdir = parse_keep_workdir(env)
     return (
         root=root,

--- a/development.md
+++ b/development.md
@@ -41,8 +41,16 @@ projects/
 
 **Build source priority:**
 
-1. `../sparse-ir-rs` if the sibling checkout exists
-2. pinned `sparse-ir-capi` `0.8.1` from crates.io otherwise
+1. `SPARSEIR_RUST_BACKEND_DIR` if set and pointing to an existing checkout
+2. `../sparse-ir-rs` if the sibling checkout exists
+3. pinned `sparse-ir-capi` `0.8.1` from crates.io otherwise
+
+If your Rust checkout lives in another worktree or directory, point the
+environment variable at it before rebuilding:
+
+```bash
+export SPARSEIR_RUST_BACKEND_DIR=/path/to/sparse-ir-rs
+```
 
 **Important:** `Pkg.add("SparseIR")` runs the build step automatically on first
 install, but `Pkg.develop(...)` does not. For development checkouts, run:
@@ -63,6 +71,9 @@ This build step:
 
 **Build-time environment variables:**
 
+- `SPARSEIR_RUST_BACKEND_DIR=/path/to/sparse-ir-rs`
+  Points `Pkg.build("SparseIR")` at a specific local Rust checkout. Relative
+  paths are resolved against the `SparseIR.jl` package root.
 - `SPARSEIR_BUILD_DEBUG=1`
   Keeps the temporary crates.io workspace after a successful build. Failed builds
   also keep the workspace path for inspection.

--- a/test/build_support_tests.jl
+++ b/test/build_support_tests.jl
@@ -16,7 +16,7 @@
     mktempdir() do root
         mkpath(joinpath(root, "deps"))
         @test BuildSupport.backend_stamp_path(root) == joinpath(root, "deps", "backend.stamp")
-        @test BuildSupport.select_build_source(root; dev_dir=joinpath(root, "..", "sparse-ir-rs")).kind == :crates_io
+        @test BuildSupport.select_build_source(root; dev_dir=joinpath(root, "missing")).kind == :crates_io
     end
 
     mktempdir() do root
@@ -90,6 +90,35 @@
         @test plan.version == expected_version
         @test plan.keep_workdir == true
         @test plan.debuginfo == "full"
+    end
+
+    mktempdir() do root
+        write(joinpath(root, "Project.toml"), """
+        [tool.sparseir]
+        rust_backend_version = "$expected_version"
+        """)
+        backend_dir = joinpath(root, "other-sparse-ir-rs")
+        mkpath(backend_dir)
+        plan = BuildSupport.build_plan(
+            root;
+            env=Dict(BuildSupport.LOCAL_RUST_BACKEND_DIR_ENV => "other-sparse-ir-rs"),
+            dev_dir=joinpath(root, "missing"),
+        )
+        @test plan.source == :local
+        @test plan.workspace == backend_dir
+    end
+
+    mktempdir() do root
+        write(joinpath(root, "Project.toml"), """
+        [tool.sparseir]
+        rust_backend_version = "$expected_version"
+        """)
+        err = @test_throws ErrorException BuildSupport.build_plan(
+            root;
+            env=Dict(BuildSupport.LOCAL_RUST_BACKEND_DIR_ENV => joinpath(root, "missing")),
+            dev_dir=joinpath(root, "sparse-ir-rs"),
+        )
+        @test occursin("points to a missing directory", sprint(showerror, err.value))
     end
 
     @test BuildSupport.crates_io_download_url(expected_version) ==


### PR DESCRIPTION
## Summary
- Add `SPARSEIR_RUST_BACKEND_DIR` to select a local Rust backend checkout, with sibling `../sparse-ir-rs` as fallback.
- Keep crates.io fallback for builds when no local checkout exists.
- Update docs and tests to reflect the new backend selection order.

## Test Plan
- [x] `julia --project=. -e "using Pkg; Pkg.test()"` (655/655 pass)