### PR TITLE
Default Rust debuginfo to line tables and add limited mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Build-time environment variables:
   Selects a local Rust backend checkout. Relative paths are resolved against
   the `SparseIR.jl` package root.
 - `SPARSEIR_BUILD_DEBUG=1` keeps the temporary crates.io workspace after a successful build.
-- `SPARSEIR_BUILD_DEBUGINFO=none|line|full` controls the Rust debuginfo level embedded in the built library.
+- `SPARSEIR_BUILD_DEBUGINFO=none|line|limited|full` controls the Rust debuginfo level embedded in the built library.
+  The default is `line`, which maps to Rust's `line-tables-only`.
 
 Build progress is recorded in `deps/build-state.toml`, and detailed cargo/binding
 logs are written to `deps/build.log`. See [`deps/README.md`](deps/README.md) and

--- a/deps/README.md
+++ b/deps/README.md
@@ -28,8 +28,9 @@ Build-time environment variables:
 - `SPARSEIR_BUILD_DEBUG=1`
   Keeps the temporary crates.io workspace after a successful build. Failed builds
   always keep the workspace path recorded in `deps/build-state.toml`.
-- `SPARSEIR_BUILD_DEBUGINFO=none|line|full`
-  Controls the Rust debuginfo level passed to cargo.
+- `SPARSEIR_BUILD_DEBUGINFO=none|line|limited|full`
+  Controls the Rust debuginfo level passed to cargo. The default is `line`,
+  which maps to Rust's `line-tables-only`.
 
 Examples:
 

--- a/deps/build_support.jl
+++ b/deps/build_support.jl
@@ -13,10 +13,12 @@ function parse_keep_workdir(env::AbstractDict)
 end
 
 function parse_debuginfo(env::AbstractDict)
-    value = get(env, "SPARSEIR_BUILD_DEBUGINFO", "none")
+    value = get(env, "SPARSEIR_BUILD_DEBUGINFO", "line")
     mapping = Dict(
         "none" => "none",
         "line" => "line-tables-only",
+        "line-tables-only" => "line-tables-only",
+        "limited" => "limited",
         "full" => "full",
     )
     haskey(mapping, value) || error("Unsupported SPARSEIR_BUILD_DEBUGINFO=$value")

--- a/development.md
+++ b/development.md
@@ -78,8 +78,9 @@ This build step:
 - `SPARSEIR_BUILD_DEBUG=1`
   Keeps the temporary crates.io workspace after a successful build. Failed builds
   also keep the workspace path for inspection.
-- `SPARSEIR_BUILD_DEBUGINFO=none|line|full`
-  Controls the debuginfo level embedded in the Rust library.
+- `SPARSEIR_BUILD_DEBUGINFO=none|line|limited|full`
+  Controls the debuginfo level embedded in the Rust library. The default is
+  `line`, which maps to Rust's `line-tables-only`.
 
 **Examples:**
 

--- a/test/build_support_tests.jl
+++ b/test/build_support_tests.jl
@@ -11,7 +11,9 @@
 
     @test BuildSupport.parse_keep_workdir(Dict("SPARSEIR_BUILD_DEBUG" => "1")) === true
     @test BuildSupport.parse_keep_workdir(Dict{String,String}()) === false
+    @test BuildSupport.parse_debuginfo(Dict{String,String}()) == "line-tables-only"
     @test BuildSupport.parse_debuginfo(Dict("SPARSEIR_BUILD_DEBUGINFO" => "line")) == "line-tables-only"
+    @test BuildSupport.parse_debuginfo(Dict("SPARSEIR_BUILD_DEBUGINFO" => "limited")) == "limited"
 
     mktempdir() do root
         mkpath(joinpath(root, "deps"))
@@ -70,7 +72,7 @@
         @test plan.workspace == dev_dir
         @test plan.version == expected_version
         @test plan.keep_workdir == false
-        @test plan.debuginfo == "none"
+        @test plan.debuginfo == "line-tables-only"
     end
 
     mktempdir() do root


### PR DESCRIPTION
## Summary
- default `SPARSEIR_BUILD_DEBUGINFO` to `line`, which maps to Rusts `line-tables-only`
- add `limited` as a supported debuginfo mode while keeping existing `line` and `full` options
- update developer-facing docs and build-support tests to cover the new default and accepted values

## Test Plan
- `julia --project=. -e 'using Pkg; Pkg.build()'
- `julia --project=. -e 'using Pkg; Pkg.test()'
- `julia --project=. -e 'include("deps/build_support.jl"); using .BuildSupport; println(BuildSupport.parse_debuginfo(Dict{String,String}())); println(BuildSupport.parse_debuginfo(Dict("SPARSEIR_BUILD_DEBUGINFO"=>"limited")))'
