### PR TITLE
[codex] update overlap docs example and local resolve note

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ function main(β = 10, ωmax = 8, ε = 1e-6)
     ρ₀(ω) = 2/π * √(1 - clamp(ω, -1, +1)^2)
     
     # Compute the IR basis coefficients for the non-interacting propagator
-    ρ₀l = overlap.(basis.v, ρ₀)
+    ρ₀l = overlap(basis.v, ρ₀)
     G₀l = -basis.s .* ρ₀l
     
     # Self-consistency loop: alternate between second-order expression for the

--- a/development.md
+++ b/development.md
@@ -27,6 +27,16 @@ using Documenter
 include("docs/make.jl")
 ```
 
+If `Pkg.instantiate()` fails because a local `Manifest.toml` has fallen out of sync
+with `Project.toml`, run `Pkg.resolve()` and then retry `Pkg.instantiate()`:
+
+```julia
+using Pkg
+Pkg.activate(".")
+Pkg.resolve()
+Pkg.instantiate()
+```
+
 ### Using Local libsparseir for Development
 
 During development, you may want to use a locally built version of `libsparseir` instead of the pre-built JLL package. This allows you to test changes to the C API immediately.
@@ -241,4 +251,3 @@ Profile.print()
 3. Ensure all tests pass
 4. Build documentation
 5. Create and push a tag
-

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -41,7 +41,7 @@ U = 1.2
 ρ₀(ω) = 2/π * √(1 - clamp(ω, -1, +1)^2)
 
 # Compute the IR basis coefficients for the non-interacting propagator
-ρ₀l = overlap.(basis.v, ρ₀)
+ρ₀l = overlap(basis.v, ρ₀)
 G₀l = -basis.s .* ρ₀l
 
 # Self-consistency loop: alternate between second-order expression for the
@@ -353,7 +353,7 @@ julia> U = 1.2
 julia> ρ₀(ω) = 2/π * √(1 - clamp(ω, -1, +1)^2)
 ρ₀ (generic function with 1 method)
 
-julia> ρ₀l = overlap.(basis.v, ρ₀)
+julia> ρ₀l = overlap(basis.v, ρ₀)
 20-element Vector{Float64}:
   0.601244316541724
   1.3444106938820255e-17
@@ -522,7 +522,7 @@ function main(; β=10.0, ωmax=8.0, ε=1e-6)
     ρ₀(ω) = 2 / π * √(1 - clamp(ω, -1, +1)^2)
 
     # Compute the IR basis coefficients for the non-interacting propagator
-    ρ₀l = overlap.(basis.v, ρ₀)::Vector{Float64}
+    ρ₀l = overlap(basis.v, ρ₀)::Vector{Float64}
     G₀l = -basis.s .* ρ₀l
 
     # Self-consistency loop: alternate between second-order expression for the


### PR DESCRIPTION
## Summary

- update the public `overlap` examples in the README and guide to use the current `overlap(basis.v, ρ₀)` form
- add a short development note explaining that `Pkg.resolve()` can recover from a stale local `Manifest.toml`
- keep the PR scope limited to the three requested documentation files

## Why

The main public example still used an obsolete broadcasted `overlap.(basis.v, ρ₀)` call, which no longer matches the current API and was reported in issue #136. While investigating that report, the local development flow also benefited from a short note about recovering from out-of-sync local manifests.

Fixes #136.

## Validation

- `JULIA_DEPOT_PATH=$PWD/.codex-julia-depot julia --project=.tmp/test-feature-env -e 'using Test; readme=read("README.md", String); guide=read(joinpath("docs","src","guide.md"), String); @test !occursin("overlap.(basis.v, ρ₀)", readme); @test !occursin("overlap.(basis.v, ρ₀)", guide); @test occursin("overlap(basis.v, ρ₀)", readme); @test occursin("overlap(basis.v, ρ₀)", guide); dev=read("development.md", String); @test occursin("Pkg.resolve()", dev); println("DOCS_VERIFY_OK")'`
- `JULIA_DEPOT_PATH=$PWD/.codex-julia-depot julia --project=.tmp/test-feature-env .tmp/test-feature/core_workflow.jl`
- `JULIA_DEPOT_PATH=$PWD/.codex-julia-depot julia --project=.tmp/test-feature-env -e 'using Pkg; Pkg.test("SparseIR")'`
